### PR TITLE
Fix csv parse crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",


### PR DESCRIPTION
Fixes #6
Record length errors were not getting caught when using the event emitter API
