### PR TITLE
Fix env var table formatting in main readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm start
 The `env.example` file has example values.  Here's what they mean:
 
 Variable | Description | Sample
--- | --
+-- | -- | --
 `CONFIG_NAME` | Name of the configuration to use | `chis-ke`
 `EXTERNAL_PORT` | Port to use in docker compose when starting the web server | `3000`
 `PORT` | For localhost development environment | `3000`


### PR DESCRIPTION
The one with the 5 char change ([reference](https://en.wikipedia.org/wiki/List_of_Friends_episodes) (I'm totally not a Friends fan, but there you are))