### PR TITLE
No the "inherit" text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "dist/index.js",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",

--- a/src/public/components/list_cell.html
+++ b/src/public/components/list_cell.html
@@ -19,5 +19,4 @@
       <span class="material-symbols-outlined">cloud_off</span>
     {% endif %}
   {% endif %}
-
 </td>

--- a/src/public/components/list_cell.html
+++ b/src/public/components/list_cell.html
@@ -18,10 +18,6 @@
     {% if include.linkTo.type == 'local' %}
       <span class="material-symbols-outlined">cloud_off</span>
     {% endif %}
-  {% else %}
-    {% if include.values.replacement %}
-      <i><small>Inherit</small></i>
-    {% endif %}
   {% endif %}
 
 </td>


### PR DESCRIPTION
#57

Previously in "CHP or CHA replacement scenarios", if data is left blank then in the summary table it will say _inherit_ instead of displaying the new data is empty.  This has been problematic and often shows up when it isn't expected and I suspect we should just remove that feature and keep things simple.