### PR TITLE
Support for email inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "main": "dist/index.js",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",

--- a/src/lib/validator-name.ts
+++ b/src/lib/validator-name.ts
@@ -8,19 +8,21 @@ export default class ValidatorName implements IValidator {
   }
 
   format(input : string, property : ContactProperty) : string {
-    const validatorStr = new ValidatorString();
+    input = input.replace(/\./g, ' ');
+    input = input.replace(/\//g, ' / ');
     let toAlter = input;
     if (property.parameter) {
       if (!Array.isArray(property.parameter)) {
         throw Error(`property of type name's parameter should be an array`);
       }
-
+      
       toAlter = property.parameter.reduce((agg, toRemove) => {
         const regex = new RegExp(toRemove, 'ig');
         return agg.replace(regex, '');
       }, toAlter);
     }
-
+    
+    const validatorStr = new ValidatorString();
     return this.titleCase(validatorStr.format(toAlter));
   }
 

--- a/src/lib/validator-string.ts
+++ b/src/lib/validator-string.ts
@@ -6,9 +6,7 @@ export default class ValidatorString implements IValidator {
   }
 
   format(input : string) : string {
-    input = input.replace(/\./g, ' ');
-    input = input.replace(/\//g, ' / ');
-    input = input.replace(/[^a-zA-Z0-9 ()/\-']/g, '');
+    input = input.replace(/[^a-zA-Z0-9 ()@\./\-']/g, '');
     input = input.replace(/\s\s+/g, ' ');
     return input.trim();
   }

--- a/src/lib/validator-string.ts
+++ b/src/lib/validator-string.ts
@@ -6,7 +6,7 @@ export default class ValidatorString implements IValidator {
   }
 
   format(input : string) : string {
-    input = input.replace(/[^a-zA-Z0-9 ()@\./\-']/g, '');
+    input = input.replace(/[^a-zA-Z0-9 ()@./\-']/g, '');
     input = input.replace(/\s\s+/g, ' ');
     return input.trim();
   }

--- a/test/lib/validation.spec.ts
+++ b/test/lib/validation.spec.ts
@@ -13,7 +13,7 @@ type Scenario = {
   error?: string;
 };
 
-const EMAIL_REGEX = '^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$';
+const EMAIL_REGEX = '^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$';
 
 const scenarios: Scenario[] = [
   { type: 'string', prop: 'abc', isValid: true },

--- a/test/lib/validation.spec.ts
+++ b/test/lib/validation.spec.ts
@@ -13,10 +13,12 @@ type Scenario = {
   error?: string;
 };
 
+const EMAIL_REGEX = '^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$';
+
 const scenarios: Scenario[] = [
   { type: 'string', prop: 'abc', isValid: true },
   { type: 'string', prop: ' ab\nc', isValid: true, altered: 'abc' },
-  { type: 'string', prop: 'Mr.  Sand(m-a-n)', isValid: true, altered: 'Mr Sand(m-a-n)' },
+  { type: 'string', prop: 'Mr.  Sand(m-a-n)', isValid: true, altered: 'Mr. Sand(m-a-n)' },
   { type: 'string', prop: '', isValid: false, altered: '', error: 'Required' },
   
   { type: 'phone', prop: '+254712345678', isValid: true, altered: '0712 345678', propertyParameter: 'KE' },
@@ -27,10 +29,13 @@ const scenarios: Scenario[] = [
   { type: 'regex', propertyParameter: '^\\d{6}$', prop: '123456', isValid: true },
   { type: 'regex', propertyParameter: '^\\d{6}$', prop: ' 123456 *&%', isValid: true, altered: '123456' },
   { type: 'regex', propertyParameter: '^\\d{6}$', prop: '1234567', isValid: false, error: 'six digit', propertyErrorDescription: 'six digit number' },
+  { type: 'regex', propertyParameter: EMAIL_REGEX, prop: 'email@address.com', isValid: true, altered: 'email@address.com' },
+  { type: 'regex', propertyParameter: EMAIL_REGEX, prop: '.com', isValid: false, propertyErrorDescription: 'valid email address', error: 'email' },
   { type: 'regex', propertyParameter: undefined, prop: 'abc', isValid: false, error: 'missing parameter' },
   
   { type: 'name', prop: 'abc', isValid: true, altered: 'Abc' },
   { type: 'name', prop: 'a b c', isValid: true, altered: 'A B C' },
+  { type: 'name', prop: 'Mr.  Sand(m-a-n)', isValid: true, altered: 'Mr Sand(m-a-n)' },
   { type: 'name', prop: 'WELDON KO(E)CH \n', isValid: true, altered: 'Weldon Ko(e)ch' },
   { type: 'name', prop: 'S \'am \'s', isValid: true, altered: 'S\'am\'s' },
   { type: 'name', prop: 'KYAMBOO/KALILUNI', isValid: true, altered: 'Kyamboo / Kaliluni' },


### PR DESCRIPTION
#82 

The ValidatorRegex uses ValidatorString. ValidatorString should control restrictions which we want to apply to all inputs. I'm relaxing that logic to allow email characters + moving some reformatting into ValidatorName where it is more appropriate.