### PR TITLE
feat(#87): add support for french characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "dist/index.js",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",

--- a/src/lib/validator-string.ts
+++ b/src/lib/validator-string.ts
@@ -6,7 +6,7 @@ export default class ValidatorString implements IValidator {
   }
 
   format(input : string) : string {
-    input = input.replace(/[^a-zA-Z0-9 ()@./\-'éôîêàèùçœ]/gu, '');
+    input = input.replace(/[^^a-zA-Z0-9À-ÖØ-öø-ÿ ()@./\-']/gu, '');
     input = input.replace(/\s\s+/g, ' ');
     return input.trim();
   }

--- a/src/lib/validator-string.ts
+++ b/src/lib/validator-string.ts
@@ -6,7 +6,7 @@ export default class ValidatorString implements IValidator {
   }
 
   format(input : string) : string {
-    input = input.replace(/[^a-zA-Z0-9 ()@./\-']/g, '');
+    input = input.replace(/[^a-zA-Z0-9 ()@./\-'éôîêàèùçœ]/gu, '');
     input = input.replace(/\s\s+/g, ' ');
     return input.trim();
   }

--- a/test/lib/validation.spec.ts
+++ b/test/lib/validation.spec.ts
@@ -20,7 +20,7 @@ const scenarios: Scenario[] = [
   { type: 'string', prop: ' ab\nc', isValid: true, altered: 'abc' },
   { type: 'string', prop: 'Mr.  Sand(m-a-n)', isValid: true, altered: 'Mr. Sand(m-a-n)' },
   { type: 'string', prop: 'Université ', isValid: true, altered: 'Université' },
-  { type: 'string', prop: 'Infirmière d\'Etat', isValid: true, altered: 'Infirmière d\'Etat' },
+  { type: 'string', prop: `Infirmière d'Etat`, isValid: true, altered: `Infirmière d'Etat` },
   { type: 'string', prop: '', isValid: false, altered: '', error: 'Required' },
   
   { type: 'phone', prop: '+254712345678', isValid: true, altered: '0712 345678', propertyParameter: 'KE' },

--- a/test/lib/validation.spec.ts
+++ b/test/lib/validation.spec.ts
@@ -19,6 +19,8 @@ const scenarios: Scenario[] = [
   { type: 'string', prop: 'abc', isValid: true },
   { type: 'string', prop: ' ab\nc', isValid: true, altered: 'abc' },
   { type: 'string', prop: 'Mr.  Sand(m-a-n)', isValid: true, altered: 'Mr. Sand(m-a-n)' },
+  { type: 'string', prop: 'Université ', isValid: true, altered: 'Université' },
+  { type: 'string', prop: 'Infirmière d\'Etat', isValid: true, altered: 'Infirmière d\'Etat' },
   { type: 'string', prop: '', isValid: false, altered: '', error: 'Required' },
   
   { type: 'phone', prop: '+254712345678', isValid: true, altered: '0712 345678', propertyParameter: 'KE' },


### PR DESCRIPTION
Fix #87 

This PR addresses the issue with the current `ValidatorString`, which fails to handle French characters ('é', 'ô', 'î', 'ê', etc.) correctly. The proposed changes update the regular expressions used for formatting  to include support for French characters.

