### PR TITLE
Improve performance of parsing CSV files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "main": "dist/index.js",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",

--- a/src/lib/cht-api.ts
+++ b/src/lib/cht-api.ts
@@ -30,16 +30,12 @@ export type RemotePlace = {
 };
 
 export class ChtApi {
-  private session: ChtSession;
+  public readonly chtSession: ChtSession;
   private axiosInstance: AxiosInstance;
 
   constructor(session: ChtSession) {
-    this.session = session;
+    this.chtSession = session;
     this.axiosInstance = session.axiosInstance;
-  }
-
-  public get chtSession(): ChtSession {
-    return this.session.clone();
   }
 
   // workaround https://github.com/medic/cht-core/issues/8674

--- a/src/lib/cht-session.ts
+++ b/src/lib/cht-session.ts
@@ -57,10 +57,6 @@ export default class ChtSession {
     return new ChtSession(parsed.authInfo, parsed.sessionToken, parsed.username, parsed.facilityId);
   }
 
-  clone(): ChtSession {
-    return new ChtSession(this.authInfo, this.sessionToken, this.username, this.facilityId);
-  }
-
   isPlaceAuthorized(remotePlace: RemotePlace): boolean {
     return !!this.facilityId &&
       (

--- a/src/lib/remote-place-resolver.ts
+++ b/src/lib/remote-place-resolver.ts
@@ -198,7 +198,6 @@ function findLocalPlaces(
   }
 
   if (places.length > 1) {
-    console.warn(`Found multiple known places for name "${name}"`);
     return {
       ...RemotePlaceResolver.Multiple,
       ambiguities: places.map(p => p.asRemotePlace()),

--- a/src/lib/remote-place-resolver.ts
+++ b/src/lib/remote-place-resolver.ts
@@ -212,7 +212,6 @@ function addKeyToMap(map: RemotePlaceMap, key: string, value: RemotePlace) {
   const lowercaseKey = key.toLowerCase();
   const existing = map[lowercaseKey];
   if (existing && existing.id !== value.id) {
-    console.warn(`Found multiple known places for name "${value.name}"`);
     if (existing.id !== RemotePlaceResolver.Multiple.id) {
       map[lowercaseKey] = {
         ...RemotePlaceResolver.Multiple,


### PR DESCRIPTION
#137 

Doing a quick profile during CSV parse, I'm seeing the majority of time is spent in `axios.create`. I'm not sure why, but when calling `chtApi.chtSession`, we are returning a clone of the session which recreates the object and creates an axios instance.  With proper use of TypeScript, I think we don't need to fear an object overwriting any information on the session and the clone is not necessary.

After this change, the majority of time is spent in the validation library and in LiquidJs. That seems like a much better place to be. Obviously, performance isn't great and we can do more. Can look at this during https://github.com/medic/cht-user-management/issues/128

Narok DataSet
Before: 44s
After: 14s
