### PR TITLE
Add certificate-arn for 2024

### DIFF
--- a/scripts/deploy/values/users-chis-ke.yaml
+++ b/scripts/deploy/values/users-chis-ke.yaml
@@ -15,7 +15,7 @@ cht-user-management:
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/healthcheck-port: traffic-port
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:iam::720541322708:server-certificate/2024-wildcard-app-medicmobile-org-chain
     className: alb
     hosts:
       - host: users-chis-ke.app.medicmobile.org

--- a/scripts/deploy/values/users-chis-tg.yaml
+++ b/scripts/deploy/values/users-chis-tg.yaml
@@ -15,7 +15,7 @@ cht-user-management:
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/healthcheck-port: traffic-port
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:iam::720541322708:server-certificate/2024-wildcard-app-medicmobile-org-chain
     className: alb
     hosts:
       - host: users-chis-tg.app.medicmobile.org

--- a/scripts/deploy/values/users-chis-ug.yaml
+++ b/scripts/deploy/values/users-chis-ug.yaml
@@ -15,7 +15,7 @@ cht-user-management:
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/healthcheck-port: traffic-port
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:iam::720541322708:server-certificate/2024-wildcard-app-medicmobile-org-chain
     className: alb
     hosts:
       - host: users-chis-ug.app.medicmobile.org


### PR DESCRIPTION
Turns out this is needed after all and should be 2024, fyi @Hareet 
I've rolled this out manually on ingresses since the versions differs from the values files here
- Related #123 