### PR TITLE
Add hint to contact properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Property | Type | Description
 `contact_types.place_properties` | Array<ConfigProperty> | Defines the attributes which are collected and set on the user's created place. See [ConfigProperty](#ConfigProperty).
 `contact_types.contact_properties` | Array<ConfigProperty> | Defines the attributes which are collected and set on the user's primary contact doc. See [ConfigProperty](#ConfigProperty).
 `contact_types.deactivate_users_on_replace` | boolean | Controls what should happen to the defunct contact and user documents when a user is replaced. When `false`, the contact and user account will be deleted. When `true`, the contact will be unaltered and the user account will be assigned the role `deactivated`. This allows for account restoration.
+`contact_types.hint` | string | Provide a brief hint or description to clarify the expected input for the property.
 `logoBase64` | Image in base64 | Logo image for your project
 
 #### ConfigProperty

--- a/src/config/chis-civ/config.json
+++ b/src/config/chis-civ/config.json
@@ -184,28 +184,32 @@
             "male": "Masculin",
             "female": "Feminin"
           },
-          "required": true
+          "required": true,
+          "hint": "Genre de l'ASC"
         },
         {
           "friendly_name": "Age",
           "property_name": "age",
           "type": "regex",
           "parameter": "^\\d{2}$",
-          "required": false
+          "required": false,
+          "hint": "Age de l'ASC"
         },
         {
           "friendly_name": "Phone Number",
           "property_name": "phone",
           "type": "regex",
           "parameter": "^\\d{10}$",
-          "required": true
+          "required": true,
+          "hint": "Numero telephone de l'ASC"
         },
         {
           "friendly_name": "Email",
           "property_name": "email",
           "type": "regex",
           "parameter": "^.+\\@.+\\..+$",
-          "required": false
+          "required": false,
+          "hint": "Email de l'ASC"
         },
         {
           "friendly_name": "Username",

--- a/src/config/chis-civ/config.json
+++ b/src/config/chis-civ/config.json
@@ -184,32 +184,28 @@
             "male": "Masculin",
             "female": "Feminin"
           },
-          "required": true,
-          "hint": "Genre de l'ASC"
+          "required": true
         },
         {
           "friendly_name": "Age",
           "property_name": "age",
           "type": "regex",
           "parameter": "^\\d{2}$",
-          "required": false,
-          "hint": "Age de l'ASC"
+          "required": false
         },
         {
           "friendly_name": "Phone Number",
           "property_name": "phone",
           "type": "regex",
           "parameter": "^\\d{10}$",
-          "required": true,
-          "hint": "Numero telephone de l'ASC"
+          "required": true
         },
         {
           "friendly_name": "Email",
           "property_name": "email",
           "type": "regex",
           "parameter": "^.+\\@.+\\..+$",
-          "required": false,
-          "hint": "Email de l'ASC"
+          "required": false
         },
         {
           "friendly_name": "Username",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,6 +25,7 @@ export type ContactType = {
   place_properties: ContactProperty[];
   contact_properties: ContactProperty[];
   deactivate_users_on_replace: boolean;
+  hint?: string;
 };
 
 export type HierarchyConstraint = {

--- a/src/liquid/place/bulk_create_form.html
+++ b/src/liquid/place/bulk_create_form.html
@@ -74,7 +74,7 @@
               <tr>
                 <td>{{ row.friendly_name }}</td>
                 <td>{{ row.required }}</td>
-                <td>Property on place{% if row.hint %}. <i>{{ row.hint }}</i>{% endif %}</td>
+                <td>{% if row.hint %}. <i>{{ row.hint }}</i> {% else %} Property on place {% endif %}</td>
               </tr>
               {% endif %}
             {% endfor %}
@@ -84,7 +84,7 @@
               <tr>
                 <td>{{ row.friendly_name }}</td>
                 <td>{{ row.required }}</td>
-                <td>Property on primary contact{% if row.hint %}. <i>{{ row.hint }}</i>{% endif %}</td>
+                <td>{% if row.hint %}. <i>{{ row.hint }}</i> {% else %} Property on primary contact {% endif %}</td>
               </tr>
               {% endif %}
             {% endfor %}

--- a/src/liquid/place/bulk_create_form.html
+++ b/src/liquid/place/bulk_create_form.html
@@ -74,7 +74,7 @@
               <tr>
                 <td>{{ row.friendly_name }}</td>
                 <td>{{ row.required }}</td>
-                <td>{% if row.hint %}. <i>{{ row.hint }}</i> {% else %} Property on place {% endif %}</td>
+                <td>{% if row.hint %} <i>{{ row.hint }}</i> {% else %} Property on place. {% endif %}</td>
               </tr>
               {% endif %}
             {% endfor %}
@@ -84,7 +84,7 @@
               <tr>
                 <td>{{ row.friendly_name }}</td>
                 <td>{{ row.required }}</td>
-                <td>{% if row.hint %}. <i>{{ row.hint }}</i> {% else %} Property on primary contact {% endif %}</td>
+                <td>{% if row.hint %} <i>{{ row.hint }}</i> {% else %} Property on primary contact. {% endif %}</td>
               </tr>
               {% endif %}
             {% endfor %}

--- a/src/liquid/place/bulk_create_form.html
+++ b/src/liquid/place/bulk_create_form.html
@@ -74,7 +74,7 @@
               <tr>
                 <td>{{ row.friendly_name }}</td>
                 <td>{{ row.required }}</td>
-                <td>Property on place</td>
+                <td>Property on place{% if row.hint %}. <i>{{ row.hint }}</i>{% endif %}</td>
               </tr>
               {% endif %}
             {% endfor %}
@@ -84,7 +84,7 @@
               <tr>
                 <td>{{ row.friendly_name }}</td>
                 <td>{{ row.required }}</td>
-                <td>Property on primary contact</td>
+                <td>Property on primary contact{% if row.hint %}. <i>{{ row.hint }}</i>{% endif %}</td>
               </tr>
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
Fix #200 

Provides a helpful hint or description for contact type properties. This is useful for offering guidance or specifying the expected format of input data, such as for "Phone Number",  "ASC Type," or "Education Level." 

These hints aim to improve the accuracy of data entry by giving **user' managers** context or examples of valid input. 