### PR TITLE
error if user tries to create a place with the defined dedup property in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Property | Type | Description
 `contact_types.contact_properties` | Array<ConfigProperty> | Defines the attributes which are collected and set on the user's primary contact doc. See [ConfigProperty](#ConfigProperty).
 `contact_types.deactivate_users_on_replace` | boolean | Controls what should happen to the defunct contact and user documents when a user is replaced. When `false`, the contact and user account will be deleted. When `true`, the contact will be unaltered and the user account will be assigned the role `deactivated`. This allows for account restoration.
 `contact_types.hint` | string | Provide a brief hint or description to clarify the expected input for the property.
+`contact_types.dedup_property` | string | The place's `property_name` used to prevent creation of duplicates under a certain parent.
 `logoBase64` | Image in base64 | Logo image for your project
 
 #### ConfigProperty

--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -288,6 +288,7 @@
       "user_role": ["community_health_volunteer"],
       "username_from_place": false,
       "deactivate_users_on_replace": false,
+      "dedup_property": "name",
       "hierarchy": [
         {
           "friendly_name": "Sub County",

--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -215,6 +215,7 @@
       "user_role": ["community_health_assistant"],
       "username_from_place": true,
       "deactivate_users_on_replace": false,
+      "dedup_property": "code",
       "hierarchy": [
         {
           "friendly_name": "Sub County",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,6 +26,7 @@ export type ContactType = {
   contact_properties: ContactProperty[];
   deactivate_users_on_replace: boolean;
   hint?: string;
+  dedup_property?: string;
 };
 
 export type HierarchyConstraint = {

--- a/src/lib/cht-api.ts
+++ b/src/lib/cht-api.ts
@@ -173,6 +173,21 @@ export class ChtApi {
     return { parent, sibling };
   };
 
+  contactByType = async (placeType: string, property: string, value: string): Promise<{ name: String; parent: String }[]> => {
+    const url = `medic/_design/medic-client/_view/contacts_by_type_freetext`;
+    const params = {
+      include_docs: true,
+      key: JSON.stringify([placeType, property + ':' + value.toLowerCase()])
+    };
+    const resp = await this.axiosInstance.get(url, { params });
+    return resp.data.rows.map((row: any) => {
+      return {
+        name: row.doc.name,
+        parent: row.doc.parent?._id
+      };
+    });
+  };
+
   getPlacesWithType = async (placeType: string)
     : Promise<RemotePlace[]> => {
     const url = `medic/_design/medic-client/_view/contacts_by_type_freetext`;

--- a/src/services/upload.new.ts
+++ b/src/services/upload.new.ts
@@ -14,6 +14,12 @@ export class UploadNewPlace implements Uploader {
   };
 
   handlePlacePayload = async (place: Place, payload: PlacePayload): Promise<string> => {
+    if (place.type.dedup_property) {
+      const contacts = await this.chtApi.contactByType(payload.contact_type, place.type.dedup_property, payload[place.type.dedup_property]);
+      if (contacts.some(c => c.parent === payload.parent)) {
+        throw new Error(place.type.friendly + ` with ${place.type.dedup_property} "${payload[place.type.dedup_property]}" already exists`);
+      }
+    }
     return await this.chtApi.createPlace(payload);
   };
 


### PR DESCRIPTION
Fixes #181 

This adds a way to prevent a user from creating duplicate places by defining a `dedup_property` on a place. The `dedup_property` is not globally unique but it is scoped to the parent place.


