### PR TITLE
Standardize port 3500, add redis compose file, update .env to sane defualts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the User Management Tool with your CHT project, you'll need to create a n
 2. Create a `config.json` file and specify the values as defined below.
 3. Add reference to your configuration folder in `src/config/config-factory.ts`.
 
-Property | Type | Description
+ Property | Type | Description
 -- | -- | --
 `domains` | Array | Controls the list of instances which the user can login to
 `domains.friendly` | string | Friendly name for the instance (eg. "Migori")
@@ -119,6 +119,12 @@ This tool is available via Docker by running `docker compose up`. Set the [Envir
 
 Create an environment file by `cp env.example .env`. Change `INTERFACE` to `127.0.0.1` and otherwise see [Environment Variables](#environment-variables) for more info.
 
+If you don't have redis running locally, you can start it with:
+
+```shell
+docker compose -f docker-compose.redis.yml up -d
+```
+
 Then run:
 
 ```
@@ -153,8 +159,8 @@ The `env.example` file has example values.  Here's what they mean:
 Variable | Description | Sample
 -- | -- | --
 `CONFIG_NAME` | Name of the configuration to use | `chis-ke`
-`EXTERNAL_PORT` | Port to use in docker compose when starting the web server | `3000`
-`PORT` | For localhost development environment | `3000`
+`EXTERNAL_PORT` | Port to use in docker compose when starting the web server | `3500`
+`PORT` | For localhost development environment | `3500`
 `COOKIE_PRIVATE_KEY` | A string used to two-way encryption of main app cookies. Production values need to be a secret. Suggest `uuidgen` to generate | `589a7f23-5bb2-4b77-ac78-f202b9b6d5e3`
 `WORKER_PRIVATE_KEY` | A string used to two-way encryption sensitive data passed to workers. Recommend to be different from `COOKIE_PRIVATE_KEY`. Production values need to be a secret. Suggest `uuidgen` to generate | `2b57pd5e-f272-og90-8u97-89a7589a7f23`
 `INTERFACE` | Interface to bind to. Leave as '0.0.0.0' for prod, suggest '127.0.0.1' for development | `127.0.0.1`

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Variable | Description | Sample
 `CHT_DEV_URL_PORT` | CHT instance when in `NODE_ENV===dev`. Needs URL and port | `192-168-1-26.local-ip.medicmobile.org:10463`
 `CHT_DEV_HTTP` |  'false' for http  'true' for https | `false`
 `REDIS_HOST` | Redis server hostname use 'redis' for docker | `redis`
-`REDIS_PORT` | Redis server port | `6378`
+`REDIS_PORT` | Redis server port | `6379`
 `CHT_USER_MANAGEMENT_IMAGE` | docker image for cht-user-management service (local development), leave empty to use published one | `cht-user-management:local `
 `CHT_USER_MANAGEMENT_WORKER_IMAGE` | docker image for cht-user-management service (local development), leave empty to use published one | `cht-user-management-worker:local`
 

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - redis-data:/data
     ports:
-      - 6378:6378
+      - 6379:6379
 
 
 volumes:

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redis:6.2-alpine
+    restart: always
+    volumes:
+      - redis-data:/data
+    ports:
+      - 6378:6378
+
+
+volumes:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: ${CHT_USER_MANAGEMENT_IMAGE:-public.ecr.aws/medic/cht-user-management:latest}
     environment:
       - NODE_ENV=${NODE_ENV:-production}
-      - EXTERNAL_PORT=${EXTERNAL_PORT:-3000}
+      - EXTERNAL_PORT=${EXTERNAL_PORT:-3500}
       - COOKIE_PRIVATE_KEY=${COOKIE_PRIVATE_KEY}
       - WORKER_PRIVATE_KEY=${WORKER_PRIVATE_KEY}
       - CONFIG_NAME=${CONFIG_NAME}
@@ -18,7 +18,7 @@ services:
       - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
     ports:
-      - '${EXTERNAL_PORT-3000}:${PORT:-3000}'
+      - '${EXTERNAL_PORT-3500}:${PORT:-3500}'
     restart: always
     command: npm start
     depends_on:

--- a/env.example
+++ b/env.example
@@ -8,7 +8,7 @@ CHT_DEV_URL_PORT=localhost:5984   # where your dev CHT instance is, hostname:por
 
 # uncomment for local development ( `npm run dev`)
 #REDIS_HOST=localhost             # Redis server hostname
-#REDIS_PORT=6378                  # Redis server port
+#REDIS_PORT=6379                  # Redis server port
 
 # normally leave these commented out unless you know what you're doing:
 #PORT=3500                        # for development environment container

--- a/env.example
+++ b/env.example
@@ -1,13 +1,17 @@
-NODE_ENV=                                             # set to "dev" to use CHT_DEV_URL_PORT below, leave empty for production
-COOKIE_PRIVATE_KEY=                                   # unique random key, use uuidgen to populate  
-WORKER_PRIVATE_KEY=                                   # unique random key, use uuidgen to populate. different from COOKIE_PRIVATE_KEY
-CONFIG_NAME=chis-ke                                   # Name of the configuration
-PORT=3000                                             # for development environmentcontainer)
-EXTERNAL_PORT=3000                                    # for docker
-INTERFACE=0.0.0.0                                     # Leave as '0.0.0.0' for prod, suggest '127.0.0.1' for development
-#REDIS_HOST=redis                                     # Redis server hostname -  only uncomment if you know what you're doing
-#REDIS_PORT=6378                                      # Redis server port -  only uncomment if you know what you're doing
-CHT_DEV_HTTP=false                                    # 'true' for http  'false' for https
-CHT_DEV_URL_PORT=localhost:5984                       # where your dev CHT instance is, hostname:port
-#CHT_USER_MANAGEMENT_IMAGE=cht-user-management:local                   # docker image for cht-user-management service - uncomment to use with local development
-#CHT_USER_MANAGEMENT_WORKER_IMAGE=cht-user-management-worker:local     # docker image for worker service  - uncomment to use with local development
+NODE_ENV=                         # set to "dev" to use CHT_DEV_URL_PORT below, leave empty for production
+COOKIE_PRIVATE_KEY=               # unique random key, use uuidgen to populate
+WORKER_PRIVATE_KEY=               # unique random key, use uuidgen to populate. different from COOKIE_PRIVATE_KEY
+CONFIG_NAME=chis-ke               # Name of the configuration
+INTERFACE=0.0.0.0                 # Leave as '0.0.0.0' for prod, suggest '127.0.0.1' for development
+CHT_DEV_HTTP=false                # 'true' for http  'false' for https
+CHT_DEV_URL_PORT=localhost:5984   # where your dev CHT instance is, hostname:port
+
+# uncomment for local development ( `npm run dev`)
+#REDIS_HOST=localhost             # Redis server hostname
+#REDIS_PORT=6378                  # Redis server port
+
+# normally leave these commented out unless you know what you're doing:
+#PORT=3500                        # for development environment container
+#EXTERNAL_PORT=3500               # for docker
+#CHT_USER_MANAGEMENT_IMAGE=cht-user-management:local               # docker image for cht-user-management service - uncomment to use with local development
+#CHT_USER_MANAGEMENT_WORKER_IMAGE=cht-user-management-worker:local # docker image for worker service  - uncomment to use with local development

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ const {
   INTERFACE
 } = process.env;
 
-const port: number = env.PORT ? parseInt(env.PORT) : 3000;
+const port: number = env.PORT ? parseInt(env.PORT) : 3500;
 
 (async () => {
   const loggerConfig = {


### PR DESCRIPTION
This PR:
* makes all instances of port `3000` now be `3500`
* moves around `env.example` to call out need for `REDIS*`  in local dev
* updates readme about running redis for `npm run dev` setups
* adds redis compose file for easily running redis in local dev setups


closes #215