### PR TITLE
change .env to use http by default

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,7 +3,7 @@ COOKIE_PRIVATE_KEY=               # unique random key, use uuidgen to populate
 WORKER_PRIVATE_KEY=               # unique random key, use uuidgen to populate. different from COOKIE_PRIVATE_KEY
 CONFIG_NAME=chis-ke               # Name of the configuration
 INTERFACE=0.0.0.0                 # Leave as '0.0.0.0' for prod, suggest '127.0.0.1' for development
-CHT_DEV_HTTP=false                # 'true' for http  'false' for https
+CHT_DEV_HTTP=true                 # 'true' for http  'false' for https
 CHT_DEV_URL_PORT=localhost:5984   # where your dev CHT instance is, hostname:port
 
 # uncomment for local development ( `npm run dev`)


### PR DESCRIPTION
oops! `CHT_DEV_HTTP` should match the value in `CHT_DEV_URL_PORT`, so it should be `true` (don't use TLS).  I changed his by accident in my last PR!