### PR TITLE
Optionally enable/disable features on contact types

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To use the User Management Tool with your CHT project, you'll need to create a n
 `contact_types.contact_properties` | Array<ConfigProperty> | Defines the attributes which are collected and set on the user's primary contact doc. See [ConfigProperty](#ConfigProperty).
 `contact_types.deactivate_users_on_replace` | boolean | Controls what should happen to the defunct contact and user documents when a user is replaced. When `false`, the contact and user account will be deleted. When `true`, the contact will be unaltered and the user account will be assigned the role `deactivated`. This allows for account restoration.
 `contact_types.hint` | string | Provide a brief hint or description to clarify the expected input for the property.
+`contact_types.feature_flags` | Array | A list of features to enable for this contact type. Acceptable values are `create`, `replace-contact` and `move`. All features are enabled by default
 `logoBase64` | Image in base64 | Logo image for your project
 
 #### ConfigProperty

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ To use the User Management Tool with your CHT project, you'll need to create a n
 `contact_types.contact_properties` | Array<ConfigProperty> | Defines the attributes which are collected and set on the user's primary contact doc. See [ConfigProperty](#ConfigProperty).
 `contact_types.deactivate_users_on_replace` | boolean | Controls what should happen to the defunct contact and user documents when a user is replaced. When `false`, the contact and user account will be deleted. When `true`, the contact will be unaltered and the user account will be assigned the role `deactivated`. This allows for account restoration.
 `contact_types.hint` | string | Provide a brief hint or description to clarify the expected input for the property.
-`contact_types.feature_flags` | Array | A list of features to enable for this contact type. Acceptable values are `create`, `replace-contact` and `move`. All features are enabled by default
+`contact_types.can_create` | boolean | Optionally disable/enable creating places of this type. Defaults to true.
+`contact_types.can_replace_contact` | boolean | Optionally disable/enable replacing contacts for places of this type. Defaults to true.
+`contact_types.can_move` | boolean | Optionally disable/enable moving places of this type. Defaults to true.
 `logoBase64` | Image in base64 | Logo image for your project
 
 #### ConfigProperty

--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -188,7 +188,6 @@
       "friendly": "West Pokot",
       "domain": "westpokot.echis.go.ke"
     },
-
     {
       "friendly": "Staging (chis-staging.health.go.ke)",
       "domain": "chis-staging.health.go.ke"
@@ -335,6 +334,41 @@
           "parameter": "KE",
           "type": "phone",
           "required": true
+        }
+      ]
+    },
+    {
+      "name": "e_household",
+      "friendly": "Household",
+      "contact_type": "f_client",
+      "user_role": [],
+      "place_properties": [],
+      "contact_properties": [],
+      "feature_flags": [
+        "move"
+      ],
+      "replacement_property": {
+        "friendly_name": "",
+        "property_name": "replacement",
+        "type": "name",
+        "required": true
+      },
+      "hierarchy": [
+        {
+          "friendly_name": "CHU",
+          "property_name": "CHU",
+          "contact_type": "c_community_health_unit",
+          "type": "name",
+          "required": true,
+          "level": 2
+        },
+        {
+          "friendly_name": "CHP Area",
+          "property_name": "CHP",
+          "contact_type": "d_community_health_volunteer_area",
+          "type": "name",
+          "required": true,
+          "level": 1
         }
       ]
     }

--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -344,9 +344,10 @@
       "user_role": [],
       "place_properties": [],
       "contact_properties": [],
-      "feature_flags": [
-        "move"
-      ],
+      "username_from_place": false,
+      "deactivate_users_on_replace": false,
+      "can_create": false,
+      "can_replace_contact": false,
       "replacement_property": {
         "friendly_name": "",
         "property_name": "replacement",

--- a/src/config/config-factory.ts
+++ b/src/config/config-factory.ts
@@ -4,43 +4,11 @@ import kenyaConfig from './chis-ke';
 import togoConfig from './chis-tg';
 import civConfig from './chis-civ';
 
-export enum Feature {
-  Create = 'create',
-  ReplaceContact = 'replace-contact',
-  Move = 'move',
-}
-
-const parseConfig = (c: any): PartnerConfig => {
-  return {
-    config: {
-      ...c.config,
-      contact_types: c.config.contact_types.map((t: any) => {
-        return {
-          ...t,
-          feature_flags: t.feature_flags?.map((v: string) => {
-            if ((Object.values(Feature) as string[]).indexOf(v) === -1) {
-              throw new Error(
-                'invalid feature flag: ' +
-                  v +
-                  '. Acceptable values are [' +
-                  Object.values(Feature).join(' | ') +
-                  ']'
-              );
-            }
-            return v as Feature;
-          }),
-        };
-      }),
-    },
-    mutate: c.mutate,
-  };
-};
-
 const CONFIG_MAP: { [key: string]: PartnerConfig } = {
-  'CHIS-KE': parseConfig(kenyaConfig),
-  'CHIS-UG': parseConfig(ugandaConfig),
-  'CHIS-TG': parseConfig(togoConfig),
-  'CHIS-CIV': parseConfig(civConfig),
+  'CHIS-KE': kenyaConfig,
+  'CHIS-UG': ugandaConfig,
+  'CHIS-TG': togoConfig,
+  'CHIS-CIV': civConfig,
 };
 
 export default function getConfigByKey(key: string = 'CHIS-KE'): PartnerConfig {

--- a/src/config/config-factory.ts
+++ b/src/config/config-factory.ts
@@ -4,11 +4,43 @@ import kenyaConfig from './chis-ke';
 import togoConfig from './chis-tg';
 import civConfig from './chis-civ';
 
+export enum Feature {
+  Create = 'create',
+  ReplaceContact = 'replace-contact',
+  Move = 'move',
+}
+
+const parseConfig = (c: any): PartnerConfig => {
+  return {
+    config: {
+      ...c.config,
+      contact_types: c.config.contact_types.map((t: any) => {
+        return {
+          ...t,
+          feature_flags: t.feature_flags?.map((v: string) => {
+            if ((Object.values(Feature) as string[]).indexOf(v) === -1) {
+              throw new Error(
+                'invalid feature flag: ' +
+                  v +
+                  '. Acceptable values are [' +
+                  Object.values(Feature).join(' | ') +
+                  ']'
+              );
+            }
+            return v as Feature;
+          }),
+        };
+      }),
+    },
+    mutate: c.mutate,
+  };
+};
+
 const CONFIG_MAP: { [key: string]: PartnerConfig } = {
-  'CHIS-KE': kenyaConfig,
-  'CHIS-UG': ugandaConfig,
-  'CHIS-TG': togoConfig,
-  'CHIS-CIV': civConfig
+  'CHIS-KE': parseConfig(kenyaConfig),
+  'CHIS-UG': parseConfig(ugandaConfig),
+  'CHIS-TG': parseConfig(togoConfig),
+  'CHIS-CIV': parseConfig(civConfig),
 };
 
 export default function getConfigByKey(key: string = 'CHIS-KE'): PartnerConfig {
@@ -17,7 +49,9 @@ export default function getConfigByKey(key: string = 'CHIS-KE'): PartnerConfig {
   const result = CONFIG_MAP[usingKey];
   if (!result) {
     const available = JSON.stringify(Object.keys(CONFIG_MAP));
-    throw Error(`Failed to start: Cannot find configuration "${usingKey}". Configurations available are ${available}`);
+    throw Error(
+      `Failed to start: Cannot find configuration '${usingKey}'. Configurations available are ${available}`
+    );
   }
 
   return result;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { ChtApi, PlacePayload } from '../lib/cht-api';
-import getConfigByKey from './config-factory';
+import getConfigByKey, { Feature } from './config-factory';
 
 export type ConfigSystem = {
   domains: AuthenticationInfo[];
@@ -26,7 +26,7 @@ export type ContactType = {
   contact_properties: ContactProperty[];
   deactivate_users_on_replace?: boolean;
   hint?: string;
-  feature_flags?: string[];
+  feature_flags?: Feature[];
 };
 
 export type HierarchyConstraint = {
@@ -123,6 +123,9 @@ export class Config {
   }
 
   public static hasMultipleRoles(contactType: ContactType): boolean {
+    if (contactType.feature_flags?.length === 1 && contactType.feature_flags.includes(Feature.Move)) {
+      return false;
+    }
     if (!contactType.user_role.length || contactType.user_role.some(role => !role.trim())) {
       throw Error(`unvalidatable config: 'user_role' property is empty or contains empty strings`);
     }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,13 +19,14 @@ export type ContactType = {
   contact_type: string;
   contact_friendly?: string;
   user_role: string[];
-  username_from_place: boolean;
+  username_from_place?: boolean;
   hierarchy: HierarchyConstraint[];
   replacement_property: ContactProperty;
   place_properties: ContactProperty[];
   contact_properties: ContactProperty[];
-  deactivate_users_on_replace: boolean;
+  deactivate_users_on_replace?: boolean;
   hint?: string;
+  feature_flags?: string[];
 };
 
 export type HierarchyConstraint = {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { ChtApi, PlacePayload } from '../lib/cht-api';
-import getConfigByKey, { Feature } from './config-factory';
+import getConfigByKey  from './config-factory';
 
 export type ConfigSystem = {
   domains: AuthenticationInfo[];
@@ -19,14 +19,16 @@ export type ContactType = {
   contact_type: string;
   contact_friendly?: string;
   user_role: string[];
-  username_from_place?: boolean;
+  username_from_place: boolean;
   hierarchy: HierarchyConstraint[];
   replacement_property: ContactProperty;
   place_properties: ContactProperty[];
   contact_properties: ContactProperty[];
-  deactivate_users_on_replace?: boolean;
+  deactivate_users_on_replace: boolean;
   hint?: string;
-  feature_flags?: Feature[];
+  can_create?: boolean;
+  can_replace_contact?: boolean;
+  can_move?: boolean;
 };
 
 export type HierarchyConstraint = {
@@ -123,7 +125,7 @@ export class Config {
   }
 
   public static hasMultipleRoles(contactType: ContactType): boolean {
-    if (contactType.feature_flags?.length === 1 && contactType.feature_flags.includes(Feature.Move)) {
+    if (contactType.can_move && (contactType.can_create === false && contactType.can_replace_contact === false)) {
       return false;
     }
     if (!contactType.user_role.length || contactType.user_role.some(role => !role.trim())) {

--- a/src/lib/remote-place-resolver.ts
+++ b/src/lib/remote-place-resolver.ts
@@ -5,7 +5,6 @@ import { RemotePlace, ChtApi } from './cht-api';
 import { Config, ContactType, HierarchyConstraint } from '../config';
 import { Validation } from './validation';
 import RemotePlaceCache from './remote-place-cache';
-import assert from 'assert';
 
 type RemotePlaceMap = { [key: string]: RemotePlace };
 

--- a/src/lib/remote-place-resolver.ts
+++ b/src/lib/remote-place-resolver.ts
@@ -112,7 +112,6 @@ export default class RemotePlaceResolver {
 
 function getFuzzFunction(place: Place, hierarchyLevel: HierarchyConstraint, contactType: ContactType) {
   const fuzzingProperty = hierarchyLevel.level === 0 ? contactType.replacement_property : hierarchyLevel;
-  assert(fuzzingProperty);
   if (fuzzingProperty.type === 'generated') {
     throw Error(`Invalid configuration: hierarchy properties cannot be of type "generated".`);
   }

--- a/src/lib/remote-place-resolver.ts
+++ b/src/lib/remote-place-resolver.ts
@@ -5,6 +5,7 @@ import { RemotePlace, ChtApi } from './cht-api';
 import { Config, ContactType, HierarchyConstraint } from '../config';
 import { Validation } from './validation';
 import RemotePlaceCache from './remote-place-cache';
+import assert from 'assert';
 
 type RemotePlaceMap = { [key: string]: RemotePlace };
 
@@ -111,6 +112,7 @@ export default class RemotePlaceResolver {
 
 function getFuzzFunction(place: Place, hierarchyLevel: HierarchyConstraint, contactType: ContactType) {
   const fuzzingProperty = hierarchyLevel.level === 0 ? contactType.replacement_property : hierarchyLevel;
+  assert(fuzzingProperty);
   if (fuzzingProperty.type === 'generated') {
     throw Error(`Invalid configuration: hierarchy properties cannot be of type "generated".`);
   }

--- a/src/liquid/app/nav.html
+++ b/src/liquid/app/nav.html
@@ -19,12 +19,20 @@
         </a>
         <div class="navbar-dropdown">
           {% for placeType in contactTypes %}
-            <div class="navbar-item">
-              <b>{{placeType.friendly}}</b>
-            </div>
-            <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=new">Create New</a>
-            <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=replace">Replace Existing</a>
-            <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=bulk">Upload from CSV</a>  
+            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "create" or placeType.feature_flags contains "replace-contact" %}
+              <div class="navbar-item">
+                <b>{{placeType.friendly}}</b>
+              </div>
+            {%endif%}
+            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "create" %}
+              <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=new">Create New</a>
+            {%endif%}
+            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "replace-contact" %}
+              <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=replace">Replace Existing</a>
+            {%endif%}
+            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "create" %}
+              <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=bulk">Upload from CSV</a>  
+            {%endif%}
           {% endfor%}
         </div>
       </div>
@@ -35,7 +43,9 @@
         </a>
         <div class="navbar-dropdown">
           {% for placeType in contactTypes %}
-            <a class="navbar-item" href="/move/{{ placeType.name }}">Move {{placeType.friendly}}</a>
+            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "move" %}
+              <a class="navbar-item" href="/move/{{ placeType.name }}">Move {{placeType.friendly}}</a>
+            {%endif%}
           {% endfor%}
         </div>
       </div>

--- a/src/liquid/app/nav.html
+++ b/src/liquid/app/nav.html
@@ -19,18 +19,18 @@
         </a>
         <div class="navbar-dropdown">
           {% for placeType in contactTypes %}
-            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "create" or placeType.feature_flags contains "replace-contact" %}
+          {% if placeType.can_create or placeType.can_create == undefined or placeType.can_replace_contact or placeType.can_replace_contact == undefined %}
               <div class="navbar-item">
                 <b>{{placeType.friendly}}</b>
               </div>
             {%endif%}
-            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "create" %}
+            {% if placeType.can_create == undefined or placeType.can_create %}
               <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=new">Create New</a>
             {%endif%}
-            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "replace-contact" %}
+            {% if placeType.can_replace_contact == undefined or placeType.can_replace_contact %}
               <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=replace">Replace Existing</a>
             {%endif%}
-            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "create" %}
+            {% if placeType.can_create == undefined or placeType.can_create %}
               <a class="navbar-item" href="/add-place?type={{ placeType.name }}&op=bulk">Upload from CSV</a>  
             {%endif%}
           {% endfor%}
@@ -43,7 +43,7 @@
         </a>
         <div class="navbar-dropdown">
           {% for placeType in contactTypes %}
-            {% if placeType.feature_flags == undefined or placeType.feature_flags contains "move" %}
+            {% if placeType.can_move == undefined or placeType.can_move %}
               <a class="navbar-item" href="/move/{{ placeType.name }}">Move {{placeType.friendly}}</a>
             {%endif%}
           {% endfor%}

--- a/src/liquid/place/directive_1_get_started.html
+++ b/src/liquid/place/directive_1_get_started.html
@@ -12,16 +12,16 @@
       <span class="material-symbols-outlined">add</span> Add {{contactType.friendly}}
     </a>
     <div class="navbar-dropdown">
-      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" %}
+      {% if contactType.can_create == undefined or contactType.can_create %}
         <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=new">Create New</a>
       {%endif%}
-      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "replace-contact" %}
+      {% if contactType.can_replace_contact == undefined or contactType.can_replace_contact %}
         <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=replace">Replace Existing</a>
       {%endif%}
-      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" %}
+      {% if contactType.can_create == undefined or contactType.can_create %}
         <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=bulk">Upload from CSV</a>
       {%endif%}
-      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "move" %}
+      {% if contactType.can_move == undefined or contactType.can_move %}
         <a class="navbar-item" href="/move/{{ contactType.name }}">Move</a>
       {%endif%}
     </div>

--- a/src/liquid/place/directive_1_get_started.html
+++ b/src/liquid/place/directive_1_get_started.html
@@ -12,10 +12,18 @@
       <span class="material-symbols-outlined">add</span> Add {{contactType.friendly}}
     </a>
     <div class="navbar-dropdown">
-      <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=new">Create New</a>
-      <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=replace">Replace Existing</a>
-      <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=bulk">Upload from CSV</a>
-      <a class="navbar-item" href="/move/{{ contactType.name }}">Move</a>
+      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" %}
+        <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=new">Create New</a>
+      {%endif%}
+      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "replace-contact" %}
+        <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=replace">Replace Existing</a>
+      {%endif%}
+      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" %}
+        <a class="navbar-item" href="/add-place?type={{ contactType.name }}&op=bulk">Upload from CSV</a>
+      {%endif%}
+      {% if contactType.feature_flags == undefined or contactType.feature_flags contains "move" %}
+        <a class="navbar-item" href="/move/{{ contactType.name }}">Move</a>
+      {%endif%}
     </div>
   </div>
 </div>

--- a/src/liquid/place/list.html
+++ b/src/liquid/place/list.html
@@ -1,6 +1,6 @@
 <div id="place_list">
   {% for contactType in contactTypes %}
-    {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" or contactType.feature_flags contains "replace-contact" %}
+    {% if contactType.can_create or contactType.can_create == undefined or contactType.can_replace_contact or contactType.can_replace_contact == undefined %}
       <div id="{{contactType.name}}" class="mb-6">
         <h2 class="title is-4">{{contactType.friendly}}</h2>
         {% if contactType.places.length > 0 %}

--- a/src/liquid/place/list.html
+++ b/src/liquid/place/list.html
@@ -1,23 +1,25 @@
 <div id="place_list">
   {% for contactType in contactTypes %}
-  <div id="{{contactType.name}}" class="mb-6">
-    <h2 class="title is-4">{{contactType.friendly}}</h2>
-    {% if contactType.places.length > 0 %}
-      <table
-        id="table_places"
-        class="table is-fullwidth is-striped is-hoverable"
-      >
-        {% include "components/table_header.html" contactType=contactType %}
-        <tbody>
-          {% for place in contactType.places %}
-            {% include "components/place_item.html" %}
-          {% endfor%}
-        </tbody>
-      </table>
-    {% else %}
-      <div class="notification is-white">
-        <i>No Results</i>
-      </div>
-    {% endif %}
+    {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" or contactType.feature_flags contains "replace-contact" %}
+      <div id="{{contactType.name}}" class="mb-6">
+        <h2 class="title is-4">{{contactType.friendly}}</h2>
+        {% if contactType.places.length > 0 %}
+          <table
+            id="table_places"
+            class="table is-fullwidth is-striped is-hoverable"
+          >
+            {% include "components/table_header.html" contactType=contactType %}
+            <tbody>
+              {% for place in contactType.places %}
+                {% include "components/place_item.html" %}
+              {% endfor%}
+            </tbody>
+          </table>
+        {% else %}
+          <div class="notification is-white">
+            <i>No Results</i>
+          </div>
+      {% endif %}
+    {%endif%}
   {% endfor %}
 </div>

--- a/src/liquid/place/list_lazy.html
+++ b/src/liquid/place/list_lazy.html
@@ -1,6 +1,6 @@
 <div id="place_list" hx-trigger="load" hx-get="/app/list" hx-target="this" hx-swap="outerHTML">
   {% for contactType in contactTypes %}
-    {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" or contactType.feature_flags contains "replace-contact" %}
+    {% if contactType.can_create or contactType.can_create == undefined or contactType.can_replace_contact or contactType.can_replace_contact == undefined %}
       <div id="{{contactType.name}}" class="mb-6">
         <h2 class="title is-4">{{contactType.friendly}}</h2>
         <div>

--- a/src/liquid/place/list_lazy.html
+++ b/src/liquid/place/list_lazy.html
@@ -1,15 +1,17 @@
 <div id="place_list" hx-trigger="load" hx-get="/app/list" hx-target="this" hx-swap="outerHTML">
   {% for contactType in contactTypes %}
-  <div id="{{contactType.name}}" class="mb-6">
-    <h2 class="title is-4">{{contactType.friendly}}</h2>
-    <div>
-      <table id="table_places" class="table is-fullwidth is-striped is-hoverable">
-        {% include "components/table_header.html" contactType=contactType %}
-      </table>
-      <div class="container p-6 is-flex is-justify-content-center is-align-content-center">
-        <img src="/public/spinner.gif" alt="Loading data" />
-      </div>
-    </div>
+    {% if contactType.feature_flags == undefined or contactType.feature_flags contains "create" or contactType.feature_flags contains "replace-contact" %}
+      <div id="{{contactType.name}}" class="mb-6">
+        <h2 class="title is-4">{{contactType.friendly}}</h2>
+        <div>
+          <table id="table_places" class="table is-fullwidth is-striped is-hoverable">
+            {% include "components/table_header.html" contactType=contactType %}
+          </table>
+          <div class="container p-6 is-flex is-justify-content-center is-align-content-center">
+            <img src="/public/spinner.gif" alt="Loading data" />
+          </div>
+        </div>
+      {%endif%}
     {% endfor %}
   </div>
 </div>

--- a/src/routes/add-place.ts
+++ b/src/routes/add-place.ts
@@ -17,6 +17,13 @@ export default async function addPlace(fastify: FastifyInstance) {
       ? Config.getContactType(queryParams.type)
       : contactTypes[contactTypes.length - 1];
     const op = queryParams.op || 'new';
+    if (contactType.feature_flags) {
+      if ((op === 'new' && !contactType.feature_flags.includes('create')) || 
+      (op === 'replace' && !contactType.feature_flags.includes('replace-contact'))) {
+        resp.status(404);
+        return;
+      }
+    }
     const tmplData = {
       view: 'add',
       logo: Config.getLogoBase64(),

--- a/src/routes/add-place.ts
+++ b/src/routes/add-place.ts
@@ -7,6 +7,7 @@ import SessionCache from '../services/session-cache';
 import RemotePlaceResolver from '../lib/remote-place-resolver';
 import { UploadManager } from '../services/upload-manager';
 import RemotePlaceCache from '../lib/remote-place-cache';
+import { Feature } from '../config/config-factory';
 
 export default async function addPlace(fastify: FastifyInstance) {
   fastify.get('/add-place', async (req, resp) => {
@@ -18,8 +19,8 @@ export default async function addPlace(fastify: FastifyInstance) {
       : contactTypes[contactTypes.length - 1];
     const op = queryParams.op || 'new';
     if (contactType.feature_flags) {
-      if ((op === 'new' && !contactType.feature_flags.includes('create')) || 
-      (op === 'replace' && !contactType.feature_flags.includes('replace-contact'))) {
+      if ((op === 'new' && !contactType.feature_flags.includes(Feature.Create)) || 
+      (op === 'replace' && !contactType.feature_flags.includes(Feature.ReplaceContact))) {
         resp.code(404).type('text/html').send('Not Found');
         return;
       }

--- a/src/routes/add-place.ts
+++ b/src/routes/add-place.ts
@@ -7,7 +7,6 @@ import SessionCache from '../services/session-cache';
 import RemotePlaceResolver from '../lib/remote-place-resolver';
 import { UploadManager } from '../services/upload-manager';
 import RemotePlaceCache from '../lib/remote-place-cache';
-import { Feature } from '../config/config-factory';
 
 export default async function addPlace(fastify: FastifyInstance) {
   fastify.get('/add-place', async (req, resp) => {
@@ -18,12 +17,10 @@ export default async function addPlace(fastify: FastifyInstance) {
       ? Config.getContactType(queryParams.type)
       : contactTypes[contactTypes.length - 1];
     const op = queryParams.op || 'new';
-    if (contactType.feature_flags) {
-      if ((op === 'new' && !contactType.feature_flags.includes(Feature.Create)) || 
-      (op === 'replace' && !contactType.feature_flags.includes(Feature.ReplaceContact))) {
-        resp.code(404).type('text/html').send('Not Found');
-        return;
-      }
+    if ((op === 'new' && contactType.can_create === false) || 
+      (op === 'replace' && contactType.can_replace_contact === false)) {
+      resp.code(404).type('text/html').send('Not Found');
+      return;
     }
     const tmplData = {
       view: 'add',

--- a/src/routes/add-place.ts
+++ b/src/routes/add-place.ts
@@ -20,7 +20,7 @@ export default async function addPlace(fastify: FastifyInstance) {
     if (contactType.feature_flags) {
       if ((op === 'new' && !contactType.feature_flags.includes('create')) || 
       (op === 'replace' && !contactType.feature_flags.includes('replace-contact'))) {
-        resp.status(404);
+        resp.code(404).type('text/html').send('Not Found');
         return;
       }
     }

--- a/src/routes/move.ts
+++ b/src/routes/move.ts
@@ -5,7 +5,6 @@ import { ChtApi } from '../lib/cht-api';
 import { FastifyInstance } from 'fastify';
 import MoveLib from '../lib/move';
 import SessionCache from '../services/session-cache';
-import { Feature } from '../config/config-factory';
 
 export default async function sessionCache(fastify: FastifyInstance) {
   fastify.get('/move/:placeType', async (req, resp) => {
@@ -14,7 +13,7 @@ export default async function sessionCache(fastify: FastifyInstance) {
     const contactTypes = Config.contactTypes();
     
     const contactType = Config.getContactType(placeType);
-    if (contactType.feature_flags && !contactType.feature_flags.includes(Feature.Move)) {
+    if (contactType.can_move === false) {
       resp.code(404).type('text/html').send('Not Found');
       return;
     }

--- a/src/routes/move.ts
+++ b/src/routes/move.ts
@@ -14,7 +14,7 @@ export default async function sessionCache(fastify: FastifyInstance) {
     
     const contactType = Config.getContactType(placeType);
     if (contactType.feature_flags && !contactType.feature_flags.includes('move')) {
-      resp.code(404).type("text/html").send("Not Found");
+      resp.code(404).type('text/html').send('Not Found');
       return;
     }
     const tmplData = {

--- a/src/routes/move.ts
+++ b/src/routes/move.ts
@@ -13,6 +13,10 @@ export default async function sessionCache(fastify: FastifyInstance) {
     const contactTypes = Config.contactTypes();
     
     const contactType = Config.getContactType(placeType);
+    if (contactType.feature_flags && !contactType.feature_flags.includes('move')) {
+      resp.code(404).type("text/html").send("Not Found");
+      return;
+    }
     const tmplData = {
       view: 'move',
       op: 'move',

--- a/src/routes/move.ts
+++ b/src/routes/move.ts
@@ -5,6 +5,7 @@ import { ChtApi } from '../lib/cht-api';
 import { FastifyInstance } from 'fastify';
 import MoveLib from '../lib/move';
 import SessionCache from '../services/session-cache';
+import { Feature } from '../config/config-factory';
 
 export default async function sessionCache(fastify: FastifyInstance) {
   fastify.get('/move/:placeType', async (req, resp) => {
@@ -13,7 +14,7 @@ export default async function sessionCache(fastify: FastifyInstance) {
     const contactTypes = Config.contactTypes();
     
     const contactType = Config.getContactType(placeType);
-    if (contactType.feature_flags && !contactType.feature_flags.includes('move')) {
+    if (contactType.feature_flags && !contactType.feature_flags.includes(Feature.Move)) {
       resp.code(404).type('text/html').send('Not Found');
       return;
     }


### PR DESCRIPTION
This PR introduces a way to explicitly enable/disable the main 3 features of this app i.e creating places, replacing contacts and moving places. This came from [this request](https://github.com/medic/cht-user-management/issues/193) where users need to be allowed to move households **but not** create/replace. All features are enabled by default but this can be configured using the `feature_flags` field.