### PR TITLE
Fix Token Expiration in contact move

### DIFF
--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken';
 import ChtSession from './cht-session';
 
 const LOGIN_EXPIRES_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
-const QUEUE_SESSION_EXPIRATION = '48h';
+const QUEUE_SESSION_EXPIRATION = '96h';
 const { COOKIE_PRIVATE_KEY, WORKER_PRIVATE_KEY } = process.env;
 const PRIVATE_KEY_SALT = '_'; // change to logout all users
 const COOKIE_SIGNING_KEY = COOKIE_PRIVATE_KEY + PRIVATE_KEY_SALT;

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -2,7 +2,7 @@ import process from 'process';
 import jwt from 'jsonwebtoken';
 import ChtSession from './cht-session';
 
-const LOGIN_EXPIRES_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
+const LOGIN_EXPIRES_AFTER_MS = 4 * 24 * 60 * 60 * 1000;
 const QUEUE_SESSION_EXPIRATION = '96h';
 const { COOKIE_PRIVATE_KEY, WORKER_PRIVATE_KEY } = process.env;
 const PRIVATE_KEY_SALT = '_'; // change to logout all users


### PR DESCRIPTION
# Description:

We are encountering several issues with the MoveContactWorker that are causing job failures. These issues are related to token expiration, command timeouts, lack of error feedback, and server availability errors. 

This PR focus on addressing them by increasing the session exp to **96h**

- [ ] Token Expiration #221:
Jobs that are retried (postponed) many times face a TokenExpiredError: jwt expired. This happens because the session token expires after 48 hours, but some jobs might take longer to complete, causing the token to expire before the job finishes. (This is quite what is intended, but what are we handling the  failed jobs in general ? manually rerun ? )

- [ ] Timeout Handling #221::
Some jobs are failing with the error cht-conf timed out. This occurs when the cht process takes too long to complete, and the job is prematurely terminated.
