### PR TITLE
fix: getWarningInfo test

### DIFF
--- a/test/lib/manage-hierarchy.spec.ts
+++ b/test/lib/manage-hierarchy.spec.ts
@@ -146,9 +146,25 @@ describe('lib/manage-hierarchy.ts', () => {
   });
 
   describe('getWarningInfo', () => {
+    let clock;
+
+    // Mocking the system clock to set the current date to June 15, 2024 (quite middle).
+    // This ensures consistent test behavior for relative date calculations.
+    // Related issue: https://github.com/medic/cht-user-management/issues/238
+    beforeEach(() => {
+      const fixedDate = DateTime.local(2024, 6, 15).toJSDate();
+      clock = sinon.useFakeTimers(fixedDate.getTime());
+    });
+  
+    afterEach(() => {
+      // Restore the original system clock behavior after tests.
+      clock.restore();
+    });
+  
+
     const fakeJob: JobParams = { jobName: 'foo', jobData: { sourceId: 'abc' }};
 
-    it('below thrsholds', async () => {
+    it('below thresholds', async () => {
       const chtApi = mockChtApi();
       chtApi.countContactsUnderPlace = sinon.stub().resolves(5);
       chtApi.lastSyncAtPlace = sinon.stub().resolves(DateTime.now().minus({ days: 100 }));


### PR DESCRIPTION
# Description
This PR fixes #238,  The tests would sometimes fail due to Luxon’s behavior of adjusting the date context based on the system’s current date.

To resolve this, we mocked the system clock in the test setup to ensure a fixed middle date (June 15, 2024) for consistent relative date calculations. This prevents test failures caused by discrepancies between the actual system date and the expected relative descriptions.