### PR TITLE
hide additional place fields in the form when it's a replacement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@bull-board/api": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/index.js",
   "dependencies": {
     "@bull-board/api": "^5.17.0",

--- a/src/liquid/place/create_form.html
+++ b/src/liquid/place/create_form.html
@@ -16,11 +16,13 @@ hx-target="this" hx-swap="outerHTML">
       {% endif %}
     {% endfor %}
 
-    {% for prop in contactType.place_properties %}
-      {%
-        include "components/contact_type_property.html" prefix="place_" prop=prop place_type=contactType.name
-      %}
-    {% endfor %}
+    {%if op != 'replace'%}
+      {% for prop in contactType.place_properties %}
+        {%
+          include "components/contact_type_property.html" prefix="place_" prop=prop place_type=contactType.name
+        %}
+      {% endfor %}
+    {%endif%}
   </section>
   <section class="section is-small">
     {% for prop in contactType.contact_properties %}


### PR DESCRIPTION
This makes it so the only fields that can be updated during the replacement (on the UI) are the primary contact, any edits on the place have to be done on the CHT instance instead. 

From discussion in https://github.com/moh-kenya/config-echis-2.0/issues/2651#issuecomment-2586329672