### PR TITLE
chore(#84): publish images on release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,8 @@
 name: Docker build and publish
 
 on:
-  push:
-    branches: main
+  release:
+    types: [published]
 
 env:
   ECR_REPO: 'public.ecr.aws/s5s3h4s7'

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -12,9 +12,10 @@ const {
 } = process.env;
 
 const getBranchVersions = () => {
-  return BRANCH === 'main' ?
-    [`${packageJson.version}`, 'latest'] :
-    [`${packageJson.version}-${BRANCH}.${BUILD_NUMBER}`];
+  if (BRANCH === 'main' || packageJson.version === BRANCH.replace('v', '')) {
+    return [`${packageJson.version}`, 'latest'];
+  }
+  return [`${packageJson.version}-${BRANCH}.${BUILD_NUMBER}`];
 };
 
 const getRepo = () => {


### PR DESCRIPTION
Fixes #84 

This makes it so docker images are only published when a github release is published. Previously, this happened for every commit pushed to the main branch making it somewhat difficult to consolidate fixes/features into a single deployment. 

This change means we'll have to change the deployment workflow:
Currently we:
1. update the package version anytime we merge something to the main branch
2. update the k8s config values to match the package version

Going foward i propose we:
1. Merge things to main without updating the package version
2. Have a dedicated Release PR that updates the package version and k8s config values
3. Create a github release after the PR gets merged to trigger deployment