### PR TITLE
feat(#24): add option to refresh search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-user-management",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-user-management",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "ISC",
       "dependencies": {
         "@bull-board/api": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-user-management",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "main": "dist/index.js",
   "dependencies": {
     "@bull-board/api": "^5.17.0",

--- a/scripts/deploy/values/users-chis-civ.yaml
+++ b/scripts/deploy/values/users-chis-civ.yaml
@@ -5,7 +5,7 @@ cht-user-management:
     enabled: true
   image:
     repository: public.ecr.aws/medic/cht-user-management
-    tag: "2.1.17" # Set this to the version of the docker image
+    tag: "2.1.18" # Set this to the version of the docker image
 
   # Environment variablues to set in the pod, for example:
   # env:
@@ -51,7 +51,7 @@ cht-user-management-worker:
   replicaCount: 1
   image:
     repository: public.ecr.aws/medic/cht-user-management-worker
-    tag: "2.1.17"
+    tag: "2.1.18"
   env:
     NODE_ENV: production
     REDIS_HOST: users-chis-civ-redis-master.users-chis-prod.svc.cluster.local

--- a/scripts/deploy/values/users-chis-ke.yaml
+++ b/scripts/deploy/values/users-chis-ke.yaml
@@ -5,7 +5,7 @@ cht-user-management:
     enabled: true
   image:
     repository: public.ecr.aws/medic/cht-user-management
-    tag: "2.1.17" # Set this to the version of the docker image
+    tag: "2.1.18" # Set this to the version of the docker image
 
   # Environment variablues to set in the pod, for example:
   # env:
@@ -52,7 +52,7 @@ cht-user-management-worker:
   replicaCount: 1
   image:
     repository: public.ecr.aws/medic/cht-user-management-worker
-    tag: "2.1.17"
+    tag: "2.1.18"
   env:
     NODE_ENV: production
     REDIS_HOST: users-chis-ke-redis-master.users-chis-prod.svc.cluster.local

--- a/scripts/deploy/values/users-chis-ml.yaml
+++ b/scripts/deploy/values/users-chis-ml.yaml
@@ -5,7 +5,7 @@ cht-user-management:
     enabled: true
   image:
     repository: public.ecr.aws/medic/cht-user-management
-    tag: "2.1.17" # Set this to the version of the docker image
+    tag: "2.1.18" # Set this to the version of the docker image
 
   # Environment variablues to set in the pod, for example:
   # env:
@@ -51,7 +51,7 @@ cht-user-management-worker:
   replicaCount: 1
   image:
     repository: public.ecr.aws/medic/cht-user-management-worker
-    tag: "2.1.17"
+    tag: "2.1.18"
   env:
     NODE_ENV: production
     REDIS_HOST: users-chis-ml-redis-master.users-chis-prod.svc.cluster.local

--- a/scripts/deploy/values/users-chis-tg.yaml
+++ b/scripts/deploy/values/users-chis-tg.yaml
@@ -5,7 +5,7 @@ cht-user-management:
     enabled: true
   image:
     repository: public.ecr.aws/medic/cht-user-management
-    tag: "2.1.17" # Set this to the version of the docker image
+    tag: "2.1.18" # Set this to the version of the docker image
 
   # Environment variablues to set in the pod, for example:
   # env:
@@ -51,7 +51,7 @@ cht-user-management-worker:
   replicaCount: 1
   image:
     repository: public.ecr.aws/medic/cht-user-management-worker
-    tag: "2.1.17"
+    tag: "2.1.18"
   env:
     NODE_ENV: production
     REDIS_HOST: users-chis-tg-redis-master.users-chis-prod.svc.cluster.local

--- a/src/liquid/app/view.liquid
+++ b/src/liquid/app/view.liquid
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="/public/bulma-tooltip.min.css">
     <link rel="stylesheet" href="/public/bulma-calendar.min.css">
     <link rel="stylesheet" href="/public/material-symbols.css">
+    <link rel="stylesheet" href="/public/app.css">
 
     <style>
       .material-symbols-outlined {

--- a/src/liquid/components/search_input.liquid
+++ b/src/liquid/components/search_input.liquid
@@ -29,9 +29,8 @@
       >
       <span
         id="refresh_{{hierarchy.level}}"
-        class="icon is-right" 
-        style="cursor: pointer; pointer-events: auto; width: auto; right: 8;" 
-        hx-post="/search?place_id={{place.id}}&type={{ type }}&op={{op}}&level={{ hierarchy.level }}&prefix={{ prefix }}&fresh=1"
+        class="icon is-right search-clear-cache-icon" 
+        hx-post="/search?place_id={{place.id}}&type={{ type }}&op={{op}}&level={{ hierarchy.level }}&prefix={{ prefix }}&clear_cache=1"
         hx-target="#search_results_{{ property_name }}"
         hx-swap="innerHTML"
         hx-indicator="#refresh_{{hierarchy.level}}">

--- a/src/liquid/components/search_input.liquid
+++ b/src/liquid/components/search_input.liquid
@@ -4,7 +4,7 @@
     {{ hierarchy.friendly_name }}
     {% if hierarchy.required %}*{% endif %}
   </label>
-  <div class="control">
+  <div class="control has-icons-right">
     <input
       id="{{ property_name }}"
       name="{{ property_name }}"
@@ -26,7 +26,18 @@
       {% if disabled == true %}
         disabled
       {% endif %}
-    >
+      >
+      <span
+        id="refresh_{{hierarchy.level}}"
+        class="icon is-right" 
+        style="cursor: pointer; pointer-events: auto; width: auto; right: 8;" 
+        hx-post="/search?place_id={{place.id}}&type={{ type }}&op={{op}}&level={{ hierarchy.level }}&prefix={{ prefix }}&fresh=1"
+        hx-target="#search_results_{{ property_name }}"
+        hx-swap="innerHTML"
+        hx-indicator="#refresh_{{hierarchy.level}}">
+          <span class="is-size-7 has-text-primary req-indicator">Refreshing...</span>
+          <span id="default" class="material-symbols-outlined">sync</span>
+      </span>
     {% assign property_name_id = property_name | append: '_id' %}
     {% if data[property_name_id] %}
       <input name="{{property_name_id}}" value="{{data[property_name_id]}}" hidden>

--- a/src/liquid/edit/contact/index.liquid
+++ b/src/liquid/edit/contact/index.liquid
@@ -8,6 +8,7 @@
     <script src="/public/sse.js"></script>
     <link rel="stylesheet" href="/public/material-symbols.css">
     <link rel="stylesheet" href="/public/bulma.min.css">
+    <link rel="stylesheet" href="/public/app.css">
   </head>
   <body>
     {% render 'app/nav.liquid',

--- a/src/liquid/new/index.liquid
+++ b/src/liquid/new/index.liquid
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/public/bulma.min.css">
     <link rel="stylesheet" href="/public/material-symbols.css">
     <link rel="stylesheet" href="/public/bulma-tooltip.min.css">
+    <link rel="stylesheet" href="/public/app.css">
   </head>
   <body>
     {% render 'app/nav.liquid',

--- a/src/liquid/reassign/index.liquid
+++ b/src/liquid/reassign/index.liquid
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/public/bulma.min.css">
     <link rel="stylesheet" href="/public/bulma-tooltip.min.css">
     <link rel="stylesheet" href="/public/material-symbols.css">
+    <link rel="stylesheet" href="/public/app.css">
   </head>
   <body>
     {% render 'app/nav.liquid',

--- a/src/public/app.css
+++ b/src/public/app.css
@@ -1,10 +1,18 @@
 .req-indicator {
   display: none;
 }
+
 .htmx-request .req-indicator {
   display: inline;
 }
-.htmx-request > span#default {
+
+.htmx-request>span#default {
   display: none;
 }
 
+.control.has-icons-right .icon.search-clear-cache-icon {
+  cursor: pointer;
+  pointer-events: auto;
+  width: auto;
+  right: 8;
+}

--- a/src/public/app.css
+++ b/src/public/app.css
@@ -1,0 +1,10 @@
+.req-indicator {
+  display: none;
+}
+.htmx-request .req-indicator {
+  display: inline;
+}
+.htmx-request > span#default {
+  display: none;
+}
+

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 
 import { Config } from '../config';
 import { ChtApi } from '../lib/cht-api';
-import { RemotePlace } from '../lib/remote-place-cache';
+import RemotePlaceCache, { RemotePlace } from '../lib/remote-place-cache';
 import SessionCache from '../services/session-cache';
 import SearchLib from '../lib/search';
 
@@ -12,6 +12,7 @@ export default async function place(fastify: FastifyInstance) {
     const queryParams: any = req.query;
     const { op, place_id: placeId, type, prefix: dataPrefix } = queryParams;
     const level = parseInt(queryParams.level);
+    const bustcache = parseInt(queryParams.fresh) === 1;
 
     const data: any = req.body;
 
@@ -29,6 +30,11 @@ export default async function place(fastify: FastifyInstance) {
     if (!hierarchyLevel) {
       throw Error(`not hierarchy constraint at ${level}`);
     }
+
+    if (bustcache) {
+      RemotePlaceCache.clear(chtApi, hierarchyLevel.contact_type);
+    }
+
     const searchResults: RemotePlace[] = await SearchLib.search(
       contactType,
       data,

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -12,7 +12,7 @@ export default async function place(fastify: FastifyInstance) {
     const queryParams: any = req.query;
     const { op, place_id: placeId, type, prefix: dataPrefix } = queryParams;
     const level = parseInt(queryParams.level);
-    const bustcache = parseInt(queryParams.fresh) === 1;
+    const shouldClearCache = parseInt(queryParams.clear_cache) === 1;
 
     const data: any = req.body;
 
@@ -31,7 +31,7 @@ export default async function place(fastify: FastifyInstance) {
       throw Error(`not hierarchy constraint at ${level}`);
     }
 
-    if (bustcache) {
+    if (shouldClearCache) {
       RemotePlaceCache.clear(chtApi, hierarchyLevel.contact_type);
     }
 


### PR DESCRIPTION
Fixes #24

This PR adds a refresh button to the search input widget which when clicked will clear the cached places at the appropriate hierarchy level and re-initiate the search request to the server