### PR TITLE
feat: add SECRET_KEY to helm values

### DIFF
--- a/scripts/deploy/values/users-chis-civ.yaml
+++ b/scripts/deploy/values/users-chis-civ.yaml
@@ -71,3 +71,6 @@ redis:
     size: 8Gi
   auth:
     enabled: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: "8.2.1-debian-12-r0"

--- a/scripts/deploy/values/users-chis-ml.yaml
+++ b/scripts/deploy/values/users-chis-ml.yaml
@@ -71,3 +71,6 @@ redis:
     size: 8Gi
   auth:
     enabled: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: "8.2.1-debian-12-r0"

--- a/scripts/deploy/values/users-chis-tg.yaml
+++ b/scripts/deploy/values/users-chis-tg.yaml
@@ -71,3 +71,6 @@ redis:
     size: 8Gi
   auth:
     enabled: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: "8.2.1-debian-12-r0"


### PR DESCRIPTION
Closes #320 

This PR adds support for the new SECRET_KEY environment variable recently introduced in the app
which is used by the API to encrypt and decrypt upload logs and must be provided as a persistent, hex-encoded secret.

Helm Chart already updated: https://github.com/medic/helm-charts/pull/51