### PR TITLE
feat: add export user details UI (cht-core#9967)

### DIFF
--- a/src/lib/cht-api.ts
+++ b/src/lib/cht-api.ts
@@ -31,6 +31,8 @@ export type CouchDoc = {
 
 export type UserInfo = {
   username: string;
+  fullname?: string;
+  phone?: string;
   place?: CouchDoc[] | CouchDoc | string[] | string;
   roles?: string[];
 };
@@ -195,14 +197,29 @@ export class ChtApi {
     }
   }
 
+  async getAllUsers(): Promise<UserInfo[]> {
+    const url = `api/v2/users`;
+    console.log('axios.get', url);
+    const resp = await this.axiosInstance.get(url);
+    return resp.data?.map((doc: any): UserInfo => ({
+      username: doc.username,
+      fullname: doc.fullname,
+      phone: doc.phone,
+      place: doc.place,
+      roles: doc.roles,
+    })) || [];
+  }
+
   async getUsersAtPlace(placeId: string): Promise<UserInfo[]> {
     const url = `api/v2/users?facility_id=${placeId}`;
     console.log('axios.get', url);
     const resp = await this.axiosInstance.get(url);
     return resp.data?.map((doc: any): UserInfo => ({
       username: doc.username,
+      fullname: doc.fullname,
+      phone: doc.phone,
       place: doc.place,
-      roles: doc.roles
+      roles: doc.roles,
     }));
   }
 
@@ -212,8 +229,10 @@ export class ChtApi {
     const resp = await this.axiosInstance.get(url);
     return resp.data?.map((doc: any): UserInfo => ({
       username: doc.username,
+      fullname: doc.fullname,
+      phone: doc.phone,
       place: doc.place,
-      roles: doc.roles
+      roles: doc.roles,
     }))[0];
   }
 

--- a/src/lib/user-details-export.ts
+++ b/src/lib/user-details-export.ts
@@ -21,8 +21,12 @@ export type UserExportData = {
 };
 
 function getPlaceIds(place: UserInfo['place']): string[] {
-  if (!place) return [];
-  if (typeof place === 'string') return [place];
+  if (!place) {
+    return [];
+  }
+  if (typeof place === 'string') {
+    return [place];
+  }
   if (Array.isArray(place)) {
     return place.map((p) => (typeof p === 'string' ? p : (p as any)._id)).filter(Boolean);
   }

--- a/src/lib/user-details-export.ts
+++ b/src/lib/user-details-export.ts
@@ -1,0 +1,107 @@
+import { ContactType } from '../config';
+import { ChtApi, UserInfo } from './cht-api';
+import { stringify } from 'csv/sync';
+
+export type UserExportRow = {
+  username: string;
+  fullname: string;
+  phone: string;
+  roles: string;
+  place: string;
+};
+
+export type UserExportGroup = {
+  contactType: ContactType;
+  users: UserExportRow[];
+};
+
+export type UserExportData = {
+  groups: UserExportGroup[];
+  totalCount: number;
+};
+
+function getPlaceIds(place: UserInfo['place']): string[] {
+  if (!place) return [];
+  if (typeof place === 'string') return [place];
+  if (Array.isArray(place)) {
+    return place.map((p) => (typeof p === 'string' ? p : (p as any)._id)).filter(Boolean);
+  }
+  if (typeof place === 'object' && '_id' in (place as object)) {
+    return [(place as any)._id];
+  }
+  return [];
+}
+
+export async function getUserExportData(
+  contactTypes: ContactType[],
+  chtApi: ChtApi
+): Promise<UserExportData> {
+  const [allUsers, ...placesPerType] = await Promise.all([
+    chtApi.getAllUsers(),
+    ...contactTypes.map((ct) => chtApi.getPlacesWithType(ct.name)),
+  ]);
+
+  // Build maps: placeId -> contactTypeName and placeId -> placeName
+  const placeToType = new Map<string, string>();
+  const placeToName = new Map<string, string>();
+
+  contactTypes.forEach((ct, i) => {
+    for (const place of placesPerType[i]) {
+      placeToType.set(place._id, ct.name);
+      placeToName.set(place._id, place.name || place._id);
+    }
+  });
+
+  // Group users by contact type based on their assigned place
+  const groupMap = new Map<string, UserExportRow[]>(
+    contactTypes.map((ct) => [ct.name, []])
+  );
+
+  for (const user of allUsers) {
+    const placeIds = getPlaceIds(user.place);
+    const matchedTypes = new Set(
+      placeIds.map((id) => placeToType.get(id)).filter(Boolean) as string[]
+    );
+
+    for (const typeName of matchedTypes) {
+      const relevantIds = placeIds.filter((id) => placeToType.get(id) === typeName);
+      const placeName = relevantIds.map((id) => placeToName.get(id) || id).join(', ');
+      groupMap.get(typeName)!.push({
+        username: user.username,
+        fullname: user.fullname || '',
+        phone: user.phone || '',
+        roles: (user.roles || []).join(', '),
+        place: placeName,
+      });
+    }
+  }
+
+  const groups: UserExportGroup[] = contactTypes
+    .map((contactType) => ({
+      contactType,
+      users: groupMap.get(contactType.name) || [],
+    }))
+    .filter((g) => g.users.length > 0);
+
+  const totalCount = groups.reduce((sum, g) => sum + g.users.length, 0);
+
+  return { groups, totalCount };
+}
+
+export function getUserExportFiles(
+  groups: UserExportGroup[]
+): { filename: string; content: string }[] {
+  return groups.map(({ contactType, users }) => ({
+    filename: `${contactType.name}_users.csv`,
+    content: stringify(users, {
+      header: true,
+      columns: [
+        { key: 'username', header: 'Username' },
+        { key: 'fullname', header: 'Full Name' },
+        { key: 'phone', header: 'Phone' },
+        { key: 'roles', header: 'Roles' },
+        { key: 'place', header: 'Place' },
+      ],
+    }),
+  }));
+}

--- a/src/liquid/app/nav.liquid
+++ b/src/liquid/app/nav.liquid
@@ -76,6 +76,10 @@
               <span class="material-symbols-outlined">list</span> History
             </a>
           {% endif %}
+          <hr class="navbar-divider">
+          <a class="navbar-item" href="/users/export">
+            <span class="material-symbols-outlined">download</span> Export Users
+          </a>
         </div>
       </div>
     </div>

--- a/src/liquid/user-export/index.liquid
+++ b/src/liquid/user-export/index.liquid
@@ -1,0 +1,103 @@
+<html>
+  <head>
+    <title>Export Users</title>
+    <script src="/public/htmx.min.js"></script>
+    <script src="/public/app.js"></script>
+    <link rel="stylesheet" href="/public/bulma.min.css">
+    <link rel="stylesheet" href="/public/bulma-tooltip.min.css">
+    <link rel="stylesheet" href="/public/material-symbols.css">
+    <link rel="stylesheet" href="/public/app.css">
+    <style>
+      .material-symbols-outlined { margin-right: 5px; }
+      .user-count-badge {
+        font-size: 0.85rem;
+        vertical-align: middle;
+        margin-left: 0.5rem;
+      }
+    </style>
+  </head>
+  <script>
+    var _paq = window._paq = window._paq || [];
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="{{MATOMO_HOST}}";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '1']);
+      _paq.push(['setUserId', '{{ session.username }}']);
+      _paq.push(['setDownloadExtensions', "zip"]);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <body>
+    {% render 'app/nav.liquid',
+      logo: logo,
+      contactTypes: navContactTypes,
+      session: session
+    %}
+
+    <div class="container is-max-desktop p-4">
+
+      <div class="is-flex is-justify-content-space-between is-align-items-center mb-5">
+        <div>
+          <h4 class="title is-4 mb-1">Export Users</h4>
+          <p class="subtitle is-6 mt-0">
+            <span class="material-symbols-outlined" style="font-size:1rem; vertical-align:middle;">group</span>
+            <strong>{{ totalCount }}</strong> user{{ totalCount != 1 | default: 's' }} in
+            <em>{{ session.authInfo.friendly }}</em>
+          </p>
+        </div>
+        <a class="button is-primary" href="/files/user-details">
+          <span class="material-symbols-outlined">download</span>
+          Export as CSV
+        </a>
+      </div>
+
+      {% if totalCount == 0 %}
+        <div class="notification is-info is-light">
+          <span class="material-symbols-outlined">info</span>
+          No users of the configured contact types were found in this CHT instance.
+        </div>
+      {% else %}
+        {% for group in groups %}
+          <div class="mb-5">
+            <h5 class="title is-5 mb-2">
+              {{ group.contactType.friendly }}
+              <span class="tag is-info is-light user-count-badge">{{ group.users | size }}</span>
+            </h5>
+            <div style="border: 1px solid #d3d3d3; border-radius: 4px; overflow-x: auto;">
+              <table class="table is-fullwidth is-striped is-hoverable mb-0">
+                <thead>
+                  <tr>
+                    <th>Username</th>
+                    <th>Full Name</th>
+                    <th>Phone</th>
+                    <th>Roles</th>
+                    <th>Place</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for user in group.users %}
+                    <tr>
+                      <td><code>{{ user.username }}</code></td>
+                      <td>{{ user.fullname }}</td>
+                      <td>{{ user.phone }}</td>
+                      <td>
+                        {% if user.roles != '' %}
+                          <span class="tag is-light">{{ user.roles }}</span>
+                        {% endif %}
+                      </td>
+                      <td>{{ user.place }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        {% endfor %}
+      {% endif %}
+
+    </div>
+  </body>
+</html>

--- a/src/routes/app.ts
+++ b/src/routes/app.ts
@@ -10,6 +10,7 @@ import SessionCache from '../services/session-cache';
 import { UploadManager } from '../services/upload-manager';
 import WarningSystem from '../warnings';
 import { UploadLogRecord } from '../services/upload-log';
+import { getUserExportData } from '../lib/user-details-export';
 
 export default async function sessionCache(fastify: FastifyInstance) {
   fastify.get('/', async (req, resp) => {
@@ -91,6 +92,21 @@ export default async function sessionCache(fastify: FastifyInstance) {
     };
 
     return resp.view('src/liquid/upload-log/index.liquid', data);
+  });
+
+  fastify.get('/users/export', async (req, resp) => {
+    const contactTypes = Config.contactTypes();
+    const chtApi = new ChtApi(req.chtSession);
+    const { groups, totalCount } = await getUserExportData(contactTypes, chtApi);
+
+    return resp.view('src/liquid/user-export/index.liquid', {
+      logo: Config.getLogoBase64(),
+      session: req.chtSession,
+      navContactTypes: contactTypes,
+      MATOMO_HOST: process.env.MATOMO_HOST,
+      groups,
+      totalCount,
+    });
   });
 
   fastify.get('/app/list', async (req, resp) => {

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -8,6 +8,8 @@ import { Config, ContactProperty } from '../config';
 import getCredentialsFiles, { getCredentialsFilesFromLog } from '../lib/credentials-file';
 import SessionCache from '../services/session-cache';
 import { UploadManager } from '../services/upload-manager';
+import { ChtApi } from '../lib/cht-api';
+import { getUserExportData, getUserExportFiles } from '../lib/user-details-export';
 
 export default async function files(fastify: FastifyInstance) {
   fastify.get('/files/template/:placeType', async (req) => {
@@ -51,6 +53,22 @@ export default async function files(fastify: FastifyInstance) {
     return zip.generateNodeStream();
   });
 
+  fastify.get('/files/user-details', async (req, reply) => {
+    const contactTypes = Config.contactTypes();
+    const chtApi = new ChtApi(req.chtSession);
+    const { groups } = await getUserExportData(contactTypes, chtApi);
+    const files = getUserExportFiles(groups);
+
+    const zip = new JSZip();
+    for (const file of files) {
+      zip.file(file.filename, file.content);
+    }
+    reply.header(
+      'Content-Disposition',
+      `attachment; filename="${Date.now()}_${req.chtSession.authInfo.friendly}_all_users.zip"`
+    );
+    return zip.generateNodeStream();
+  });
 }
 
 function getCsvTemplateColumns(placeType: string) {


### PR DESCRIPTION
- Add GET /users/export page showing all CHT instance users grouped by contact type with live user count per type and total
- Add GET /files/user-details endpoint that downloads a ZIP of CSV files (one per contact type) with username, full name, phone, roles, and place
- Add getAllUsers() to ChtApi using CHT /api/v2/users endpoint; extend UserInfo with fullname and phone fields
- Add new src/lib/user-details-export.ts with getUserExportData() and getUserExportFiles() helpers
- Add "Export Users" link to the Users nav dropdown

https://claude.ai/code/session_01NSnccsTsSPbYb6vYxk1JhP