### PR TITLE
fix(#346): sync Kenyan eCHIS URLs to match production domains

### DIFF
--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -2,59 +2,59 @@
   "domains": [
     {
       "friendly": "Migori",
-      "domain": "migori-echis.health.go.ke"
+      "domain": "migori.echis.go.ke"
     },
     {
       "friendly": "Kisumu",
-      "domain": "kisumu-echis.health.go.ke"
+      "domain": "kisumu.echis.go.ke"
     },
     {
       "friendly": "Nyeri",
-      "domain": "nyeri-echis.health.go.ke"
+      "domain": "nyeri.echis.go.ke"
     },
     {
       "friendly": "Kilifi",
-      "domain": "kilifi-echis.health.go.ke"
+      "domain": "kilifi.echis.go.ke"
     },
     {
       "friendly": "Machakos",
-      "domain": "machakos-echis.health.go.ke"
+      "domain": "machakos.echis.go.ke"
     },
     {
       "friendly": "Garissa",
-      "domain": "garissa-echis.health.go.ke"
+      "domain": "garissa.echis.go.ke"
     },
     {
       "friendly": "Nakuru",
-      "domain": "nakuru-echis.health.go.ke"
+      "domain": "nakuru.echis.go.ke"
     },
     {
       "friendly": "Isiolo",
-      "domain": "isiolo-echis.health.go.ke"
+      "domain": "isiolo.echis.go.ke"
     },
     {
       "friendly": "Nairobi",
-      "domain": "nairobi-echis.health.go.ke"
+      "domain": "nairobi.echis.go.ke"
     },
     {
       "friendly": "Turkana",
-      "domain": "turkana-echis.health.go.ke"
+      "domain": "turkana.echis.go.ke"
     },
     {
       "friendly": "Kakamega",
-      "domain": "kakamega-echis.health.go.ke"
+      "domain": "kakamega.echis.go.ke"
     },
     {
       "friendly": "Vihiga",
-      "domain": "vihiga-echis.health.go.ke"
+      "domain": "vihiga.echis.go.ke"
     },
     {
       "friendly": "Kitui",
-      "domain": "kitui-echis.health.go.ke"
+      "domain": "kitui.echis.go.ke"
     },
     {
       "friendly": "Uasin Gishu",
-      "domain": "uasingishu-echis.health.go.ke"
+      "domain": "uasingishu.echis.go.ke"
     },
     {
       "friendly": "Baringo",
@@ -73,7 +73,7 @@
       "domain": "busia.echis.go.ke"
     },
     {
-      "friendly": "Elgeyo Marakwet",
+      "friendly": "Elgeyo-Marakwet",
       "domain": "elgeyomarakwet.echis.go.ke"
     },
     {
@@ -137,7 +137,7 @@
       "domain": "mombasa.echis.go.ke"
     },
     {
-      "friendly": "Muranga",
+      "friendly": "Murangaa",
       "domain": "muranga.echis.go.ke"
     },
     {
@@ -165,19 +165,19 @@
       "domain": "siaya.echis.go.ke"
     },
     {
-      "friendly": "Taita Taveta",
+      "friendly": "Taita-Taveta",
       "domain": "taitataveta.echis.go.ke"
     },
     {
-      "friendly": "Tana River",
+      "friendly": "Tana-River",
       "domain": "tanariver.echis.go.ke"
     },
     {
-      "friendly": "Tharaka Nithi",
+      "friendly": "Tharaka-Nithi",
       "domain": "tharakanithi.echis.go.ke"
     },
     {
-      "friendly": "Trans Nzoia",
+      "friendly": "Trans-Nzoia",
       "domain": "transnzoia.echis.go.ke"
     },
     {
@@ -189,8 +189,8 @@
       "domain": "westpokot.echis.go.ke"
     },
     {
-      "friendly": "Staging (chis-staging.health.go.ke)",
-      "domain": "chis-staging.health.go.ke"
+      "friendly": "Staging",
+      "domain": "staging.echis.go.ke"
     },
     {
       "friendly": "Training 1",

--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -73,7 +73,7 @@
       "domain": "busia.echis.go.ke"
     },
     {
-      "friendly": "Elgeyo-Marakwet",
+      "friendly": "Elgeyo Marakwet",
       "domain": "elgeyomarakwet.echis.go.ke"
     },
     {
@@ -137,7 +137,7 @@
       "domain": "mombasa.echis.go.ke"
     },
     {
-      "friendly": "Murangaa",
+      "friendly": "Muranga",
       "domain": "muranga.echis.go.ke"
     },
     {
@@ -165,19 +165,19 @@
       "domain": "siaya.echis.go.ke"
     },
     {
-      "friendly": "Taita-Taveta",
+      "friendly": "Taita Taveta",
       "domain": "taitataveta.echis.go.ke"
     },
     {
-      "friendly": "Tana-River",
+      "friendly": "Tana River",
       "domain": "tanariver.echis.go.ke"
     },
     {
-      "friendly": "Tharaka-Nithi",
+      "friendly": "Tharaka Nithi",
       "domain": "tharakanithi.echis.go.ke"
     },
     {
-      "friendly": "Trans-Nzoia",
+      "friendly": "Trans Nzoia",
       "domain": "transnzoia.echis.go.ke"
     },
     {


### PR DESCRIPTION
Closes #346 

- The URLs for `chis-moh-ke` are abit outdated. Update to the latest versions of the URLS