### PR TITLE
feat(#355): additional API endpoints for CHW-R integration

### DIFF
--- a/src/lib/cht-api.ts
+++ b/src/lib/cht-api.ts
@@ -4,6 +4,7 @@ import ChtSession from './cht-session';
 import { Config, ContactType } from '../config';
 import { DateTime } from 'luxon';
 import { UserPayload } from '../services/user-payload';
+import { OidcUserPayload } from '../services/oidc-user-payload';
 
 export type PlacePayload = {
   name: string;
@@ -139,7 +140,7 @@ export class ChtApi {
     return resp.data?.rows?.length || 0;
   }
 
-  async createUser(user: UserPayload): Promise<void> {
+  async createUser(user: UserPayload | OidcUserPayload): Promise<void> {
     const url = `api/v3/users`;
     console.log('axios.post', url);
     const axiosRequestionConfig = {

--- a/src/lib/remote-place-cache.ts
+++ b/src/lib/remote-place-cache.ts
@@ -62,15 +62,22 @@ export default class RemotePlaceCache {
     const cacheKey = this.getCacheKey(domain, placeType);
 
     const places = this.cache.get<RemotePlace[]>(cacheKey);
-    if (places) {
-      const existingIndex = places.findIndex(p => p.id === place.id);
-      if (existingIndex >= 0) {
-        places[existingIndex] = place.asRemotePlace();
-      } else {
-        places.push(place.asRemotePlace());
-      }
-      this.cache.set(cacheKey, places);
+    // Only patch an already-populated list. If this type isn't cached, leave it absent so the next
+    // fetch loads the full set from CHT 
+    if (!places) {
+      return;
     }
+
+    // asRemotePlace() already keys a created place by its real CHT doc id, so this entry matches a
+    // fresh fetch and re-adds dedupe correctly.
+    const remotePlace = place.asRemotePlace();
+    const existingIndex = places.findIndex(p => p.id === remotePlace.id);
+    if (existingIndex >= 0) {
+      places[existingIndex] = remotePlace;
+    } else {
+      places.push(remotePlace);
+    }
+    this.cache.set(cacheKey, places);
   }
 
   public static clear(chtApi: ChtApi, contactTypeName?: string): void {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import { ChtApi } from '../lib/cht-api';
 import { Config } from '../config';
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyRequest } from 'fastify';
 import Fuse from 'fuse.js';
 import Place, { PlaceUploadState } from '../services/place';
 import PlaceFactory from '../services/place-factory';
@@ -13,6 +13,7 @@ import RemotePlaceResolver from '../lib/remote-place-resolver';
 import WarningSystem from '../warnings';
 import { DisableUsers } from '../lib/disable-users';
 import { SetUserFacilities } from '../services/set-user-facilities';
+import { OidcUserPayload } from '../services/oidc-user-payload';
 
 const DEFAULT_THRESHOLD = 0.6;
 
@@ -29,7 +30,7 @@ type HierarchyResolutionError = {
 };
 
 export default async function api(fastify: FastifyInstance) {
-  fastify.post('/api/v1/create', async (req) => {
+  const createUserAndPlace = async (req: FastifyRequest) => {
     const formBody: any = req.body;
     ensureJsonObjectBody(formBody);
 
@@ -66,6 +67,30 @@ export default async function api(fastify: FastifyInstance) {
       password: place.creationDetails.password,
       warnings: place.warnings,
     };
+  };
+  // /create-user-and-place is the descriptive name; /create is kept as an alias for compatibility.
+  fastify.post('/api/v1/create', createUserAndPlace);
+  fastify.post('/api/v1/create-user-and-place', createUserAndPlace);
+
+  fastify.post('/api/v1/create-user', async (req) => {
+    const formBody: any = req.body;
+    ensureJsonObjectBody(formBody);
+
+    const roles = normalizeRoles(formBody);
+    const { oidc_username: oidcUsername, facility_ids: facilityIds, contact_id: contactId } = formBody;
+    const validationError = validateCreateUser(oidcUsername, roles, facilityIds, contactId);
+    if (validationError) {
+      return { success: false, errors: validationError };
+    }
+
+    const chtApi = new ChtApi(req.chtSession);
+    try {
+      const payload = new OidcUserPayload(oidcUsername, roles, facilityIds, contactId);
+      await chtApi.createUser(payload);
+      return { success: true, username: payload.username };
+    } catch (e: any) {
+      return { error: e.response?.data?.error?.message ?? e.toString() };
+    }
   });
 
   fastify.post('/api/v1/search', async (req) => {
@@ -159,15 +184,50 @@ function ensureJsonObjectBody(body: unknown) {
   }
 }
 
+// Accepts either `roles` (array) or `role` (string) from the payload and returns a clean list.
+function normalizeRoles(body: any): string[] {
+  const raw = body.roles ?? body.role;
+  const list = Array.isArray(raw) ? raw : [raw];
+  return list.filter(role => typeof role === 'string' && role.trim());
+}
+
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value)
+    && value.length > 0
+    && value.every(item => typeof item === 'string' && item.trim() !== '');
+}
+
+function validateCreateUser(
+  oidcUsername: unknown,
+  roles: string[],
+  facilityIds: unknown,
+  contactId: unknown,
+): string | null {
+  if (typeof oidcUsername !== 'string' || !oidcUsername.trim()) {
+    return 'oidc_username is required';
+  }
+
+  if (!roles.length) {
+    return 'role is required';
+  }
+
+  if (!isNonEmptyStringArray(facilityIds)) {
+    return 'facility_ids must be a non-empty array of place ids';
+  }
+
+  if (typeof contactId !== 'string' || !contactId.trim()) {
+    return 'contact_id is required';
+  }
+
+  return null;
+}
+
 function validateSetUserFacilities(username: unknown, facilityIds: unknown): string | null {
   if (typeof username !== 'string' || !username.trim()) {
     return 'username is required';
   }
 
-  const isNonEmptyStringArray = Array.isArray(facilityIds)
-    && facilityIds.length > 0
-    && facilityIds.every(id => typeof id === 'string' && id.trim());
-  if (!isNonEmptyStringArray) {
+  if (!isNonEmptyStringArray(facilityIds)) {
     return 'facility_ids must be a non-empty array of place ids';
   }
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -11,6 +11,7 @@ import SessionCache from '../services/session-cache';
 import RemotePlaceCache from '../lib/remote-place-cache';
 import RemotePlaceResolver from '../lib/remote-place-resolver';
 import WarningSystem from '../warnings';
+import { DisableUsers } from '../lib/disable-users';
 
 const DEFAULT_THRESHOLD = 0.6;
 
@@ -67,51 +68,39 @@ export default async function api(fastify: FastifyInstance) {
   });
 
   fastify.post('/api/v1/search', async (req) => {
-    const queryParams: any = req.query;
-    const threshold = queryParams.threshold !== undefined
-      ? parseFloat(queryParams.threshold)
-      : DEFAULT_THRESHOLD;
-
     const formBody: any = req.body;
     ensureJsonObjectBody(formBody);
 
-    const contactType = Config.getContactType(formBody.type);
-    const [baseHierarchyLevel] = Config.getHierarchyWithReplacement(contactType);
-
     const chtApi = new ChtApi(req.chtSession);
-
-    const { sessionCache } = req;
-    // API requests are intended to be atomic and should not rely on the state of the session
-    sessionCache.removeAll();
-    
-    const data = _.pick(formBody, Config.getHierarchyWithReplacement(contactType).slice(1).map(l => l.property_name));
-    const place = await PlaceFactory.createOne(data, contactType, sessionCache, chtApi, '');
-
-    const hierarchyError = hierarchyResolutionError(place);
-    if (hierarchyError) {
-      return hierarchyError;
+    const resolution = await resolvePlacesFromHierarchy(formBody, getThreshold(req.query), chtApi, req.sessionCache);
+    if ('error' in resolution) {
+      return resolution;
     }
 
-    const parentId = place.resolvedHierarchy[1]?.id;
-    const placesHavingParent = (await RemotePlaceCache.getRemotePlaces(chtApi, contactType, baseHierarchyLevel))
-      .filter(remotePlace => remotePlace.lineage[0] === parentId);
+    return resolution.hits;
+  });
 
-    const fuse = new Fuse(placesHavingParent, {
-      keys: ['name.formatted'],
-      includeScore: true,
-      threshold,
-    });
+  fastify.post('/api/v1/deactivate-users', async (req) => {
+    const formBody: any = req.body;
+    ensureJsonObjectBody(formBody);
 
-    const hits: SearchResult[] = fuse
-      .search(formBody[baseHierarchyLevel.property_name] ?? '')
-      .map(({ item, score }) => ({
-        name: item.name.original,
-        place_id: item.id,
-        score: score ?? 1,
-      }))
-      .sort((a, b) => a.score - b.score);
+    const chtApi = new ChtApi(req.chtSession);
+    const resolution = await resolvePlacesFromHierarchy(formBody, getThreshold(req.query), chtApi, req.sessionCache);
+    if ('error' in resolution) {
+      return resolution;
+    }
 
-    return hits;
+    const [facility] = resolution.hits;
+    if (!facility) {
+      return { success: false, error: 'no facility found matching the provided hierarchy' };
+    }
+
+    const deactivated = await DisableUsers.deactivateUsersAt([facility.place_id], chtApi);
+    return {
+      place_id: facility.place_id,
+      place_name: facility.name,
+      deactivated,
+    };
   });
 
   fastify.post('/api/v1/manage-hierarchy', async (req) => {
@@ -149,6 +138,56 @@ function ensureJsonObjectBody(body: unknown) {
   if (!_.isPlainObject(body)) {
     throw new Error('body expected as application/json');
   }
+}
+
+function getThreshold(query: unknown): number {
+  const threshold = (query as any)?.threshold;
+  return threshold !== undefined ? parseFloat(threshold) : DEFAULT_THRESHOLD;
+}
+
+// Resolves the parent hierarchy from form data and fuzzy-matches the base-level place by name,
+// returning the candidate places ranked best-first. Shared by /search and /deactivate-users so
+// both resolve a facility identically.
+async function resolvePlacesFromHierarchy(
+  formBody: any,
+  threshold: number,
+  chtApi: ChtApi,
+  sessionCache: SessionCache,
+): Promise<HierarchyResolutionError | { hits: SearchResult[] }> {
+  const contactType = Config.getContactType(formBody.type);
+  const [baseHierarchyLevel] = Config.getHierarchyWithReplacement(contactType);
+
+  // API requests are intended to be atomic and should not rely on the state of the session
+  sessionCache.removeAll();
+
+  const data = _.pick(formBody, Config.getHierarchyWithReplacement(contactType).slice(1).map(l => l.property_name));
+  const place = await PlaceFactory.createOne(data, contactType, sessionCache, chtApi, '');
+
+  const hierarchyError = hierarchyResolutionError(place);
+  if (hierarchyError) {
+    return hierarchyError;
+  }
+
+  const parentId = place.resolvedHierarchy[1]?.id;
+  const placesHavingParent = (await RemotePlaceCache.getRemotePlaces(chtApi, contactType, baseHierarchyLevel))
+    .filter(remotePlace => remotePlace.lineage[0] === parentId);
+
+  const fuse = new Fuse(placesHavingParent, {
+    keys: ['name.formatted'],
+    includeScore: true,
+    threshold,
+  });
+
+  const hits: SearchResult[] = fuse
+    .search(formBody[baseHierarchyLevel.property_name] ?? '')
+    .map(({ item, score }) => ({
+      name: item.name.original,
+      place_id: item.id,
+      score: score ?? 1,
+    }))
+    .sort((a, b) => a.score - b.score);
+
+  return { hits };
 }
 
 function hierarchyResolutionError(place: Place): HierarchyResolutionError | null {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -106,7 +106,7 @@ export default async function api(fastify: FastifyInstance) {
     return resolution.hits;
   });
 
-  fastify.post('/api/v1/deactivate-users', async (req) => {
+  fastify.post('/api/v1/disable-users-at', async (req) => {
     const formBody: any = req.body;
     ensureJsonObjectBody(formBody);
 
@@ -121,11 +121,22 @@ export default async function api(fastify: FastifyInstance) {
       return { success: false, error: 'no facility found matching the provided hierarchy' };
     }
 
-    const deactivated = await DisableUsers.deactivateUsersAt([facility.place_id], chtApi);
+    // Abort rather than guess
+    const tiedForBestMatch = resolution.hits.filter(hit => hit.score === facility.score);
+    if (tiedForBestMatch.length > 1) {
+      const joinedNames = tiedForBestMatch.map(hit => hit.name).join(', ');
+      return {
+        success: false,
+        isDuplicate: true,
+        error: `ambiguous match: ${tiedForBestMatch.length} facilities tie for the best match (${joinedNames})`,
+      };
+    }
+
+    const disabled = await DisableUsers.disableUsersAt([facility.place_id], chtApi);
     return {
       place_id: facility.place_id,
       place_name: facility.name,
-      deactivated,
+      disabled,
     };
   });
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -98,6 +98,11 @@ export default async function api(fastify: FastifyInstance) {
     ensureJsonObjectBody(formBody);
 
     const chtApi = new ChtApi(req.chtSession);
+    
+    if (shouldClearCache(req.query)) {
+      RemotePlaceCache.clear(chtApi);
+    }
+
     const resolution = await resolvePlacesFromHierarchy(formBody, getThreshold(req.query), chtApi, req.sessionCache);
     if ('error' in resolution) {
       return resolution;
@@ -248,6 +253,11 @@ function validateSetUserFacilities(username: unknown, facilityIds: unknown): str
 function getThreshold(query: unknown): number {
   const threshold = (query as any)?.threshold;
   return threshold !== undefined ? parseFloat(threshold) : DEFAULT_THRESHOLD;
+}
+
+function shouldClearCache(query: any): boolean {
+  const raw = query?.clear_cache;
+  return raw === '1' || raw === 1 || raw === 'true' || raw === true;
 }
 
 // Resolves the parent hierarchy from form data and fuzzy-matches the base-level place by name,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,6 +12,7 @@ import RemotePlaceCache from '../lib/remote-place-cache';
 import RemotePlaceResolver from '../lib/remote-place-resolver';
 import WarningSystem from '../warnings';
 import { DisableUsers } from '../lib/disable-users';
+import { SetUserFacilities } from '../services/set-user-facilities';
 
 const DEFAULT_THRESHOLD = 0.6;
 
@@ -103,6 +104,24 @@ export default async function api(fastify: FastifyInstance) {
     };
   });
 
+  fastify.post('/api/v1/set-user-facilities', async (req) => {
+    const formBody: any = req.body;
+    ensureJsonObjectBody(formBody);
+
+    const { username, facility_ids: facilityIds } = formBody;
+    const validationError = validateSetUserFacilities(username, facilityIds);
+    if (validationError) {
+      return { success: false, errors: validationError };
+    }
+
+    const chtApi = new ChtApi(req.chtSession);
+    try {
+      return await SetUserFacilities.setFacilities(username, facilityIds, chtApi);
+    } catch (e: any) {
+      return { error: e.response?.data?.error?.message ?? e.toString() };
+    }
+  });
+
   fastify.post('/api/v1/manage-hierarchy', async (req) => {
     const sessionCache: SessionCache = req.sessionCache;
     const chtApi = new ChtApi(req.chtSession);
@@ -138,6 +157,21 @@ function ensureJsonObjectBody(body: unknown) {
   if (!_.isPlainObject(body)) {
     throw new Error('body expected as application/json');
   }
+}
+
+function validateSetUserFacilities(username: unknown, facilityIds: unknown): string | null {
+  if (typeof username !== 'string' || !username.trim()) {
+    return 'username is required';
+  }
+
+  const isNonEmptyStringArray = Array.isArray(facilityIds)
+    && facilityIds.length > 0
+    && facilityIds.every(id => typeof id === 'string' && id.trim());
+  if (!isNonEmptyStringArray) {
+    return 'facility_ids must be a non-empty array of place ids';
+  }
+
+  return null;
 }
 
 function getThreshold(query: unknown): number {

--- a/src/services/oidc-user-payload.ts
+++ b/src/services/oidc-user-payload.ts
@@ -1,0 +1,25 @@
+import { sanitizeUsername } from './username';
+
+// The minimum payload to create an offline, multi-place OIDC (SSO) user in CHT. Such a user
+// authenticates via the identity provider, so no password/token_login is set (CHT forbids
+// combining those with oidc_username).
+//
+// - `place` is the array of facility ids (CHT maps it to facility_id[]). Assigning more than one
+//   requires the user's roles to carry the `can_have_multiple_places` permission.
+// - `contact` is required: CHT requires a contact for offline roles.
+export class OidcUserPayload {
+  public readonly username: string;
+  public readonly oidc_username: string;
+  public readonly roles: string[];
+  public readonly place: string[];
+  public readonly contact: string;
+
+  constructor(oidcUsername: string, roles: string[], facilityIds: string[], contactId: string) {
+    this.oidc_username = oidcUsername;
+    this.roles = roles;
+    this.place = facilityIds;
+    this.contact = contactId;
+    // username is derived from oidc_username using the same rule as place-based usernames
+    this.username = sanitizeUsername(oidcUsername);
+  }
+}

--- a/src/services/place.ts
+++ b/src/services/place.ts
@@ -8,6 +8,7 @@ import { PlacePayload } from '../lib/cht-api';
 // can't use package.json because of rootDir in ts
 import { RemotePlace } from '../lib/remote-place-cache';
 import RemotePlaceResolver from '../lib/remote-place-resolver';
+import { sanitizeUsername } from './username';
 import { version as appVersion } from '../package.json';
 
 export type FormattedPropertyCollection = {
@@ -221,18 +222,8 @@ export default class Place {
   public generateUsername(): string {
     const propertySource = this.type.username_from_place ? this.properties : this.contact.properties;
     // if name is not present, it must be a replacement
-    let username = propertySource.name?.formatted || this.hierarchyProperties.replacement?.formatted;
-    username = username
-      ?.replace(/[ ]/g, '_')
-      ?.replace(/[^a-zA-Z0-9_]/g, '')
-      ?.replace(/_+/g, '_')
-      ?.toLowerCase();
-
-    if (!username) {
-      throw Error('username cannot be empty');
-    }
-
-    return username;
+    const source = propertySource.name?.formatted || this.hierarchyProperties.replacement?.formatted;
+    return sanitizeUsername(source);
   }
 
   public get userRoles(): string[] {

--- a/src/services/place.ts
+++ b/src/services/place.ts
@@ -185,7 +185,8 @@ export default class Place {
   public asRemotePlace() : RemotePlace {
     const nameProperty = Config.getPropertyWithName(this.type.place_properties, 'name');
     return {
-      id: this.id,
+      // once created, identify by the real CHT doc id (not the local staging uuid)
+      id: this.creationDetails.placeId ?? this.id,
       name: new RemotePlacePropertyValue(this.name, nameProperty),
       placeType: this.type.name,
       type: this.isCreated ? 'remote' : 'local',

--- a/src/services/set-user-facilities.ts
+++ b/src/services/set-user-facilities.ts
@@ -1,0 +1,69 @@
+import { ChtApi, CouchDoc, UserInfo } from '../lib/cht-api';
+
+export type SetUserFacilitiesResult = {
+  username: string;
+  facilityIds: string[];
+  unassigned: { username: string; remaining: string[] }[];
+};
+
+// Sets a CHT user's facilities to exactly `facilityIds` (keyed on username), treating
+// facilities as exclusive to a single user: any other user currently holding one of these
+// facilities has it removed. A displaced user left with no facilities keeps an empty list
+// (they are not disabled) — see /api/v1/set-user-facilities.
+export class SetUserFacilities {
+  public static async setFacilities(
+    username: string,
+    facilityIds: string[],
+    chtApi: ChtApi,
+  ): Promise<SetUserFacilitiesResult> {
+    // Capture who currently holds these facilities *before* reassigning, so the target user
+    // (once assigned) isn't caught in the unassignment sweep.
+    const displaced = await this.getOtherUsersAt(facilityIds, username, chtApi);
+
+    // Assign the requested facilities to the target user. This replaces their facility list.
+    await chtApi.updateUser({ username, place: facilityIds });
+
+    // Strip the reassigned facilities from every other user that held them.
+    const reassigned = new Set(facilityIds);
+    const unassigned: { username: string; remaining: string[] }[] = [];
+    for (const user of displaced) {
+      const remaining = user.placeIds.filter(id => !reassigned.has(id));
+      await chtApi.updateUser({ username: user.username, place: remaining });
+      unassigned.push({ username: user.username, remaining });
+    }
+
+    return { username, facilityIds, unassigned };
+  }
+
+  private static async getOtherUsersAt(
+    facilityIds: string[],
+    excludeUsername: string,
+    chtApi: ChtApi,
+  ): Promise<{ username: string; placeIds: string[] }[]> {
+    const byUsername = new Map<string, { username: string; placeIds: string[] }>();
+    for (const facilityId of facilityIds) {
+      const usersAtPlace = await chtApi.getUsersAtPlace(facilityId);
+      for (const user of usersAtPlace) {
+        // getUsersAtPlace returns each user's full facility list, so the first sighting of a
+        // user captures everything we need; skip the target and any user already seen.
+        if (user.username === excludeUsername || byUsername.has(user.username)) {
+          continue;
+        }
+        byUsername.set(user.username, {
+          username: user.username,
+          placeIds: normalizePlaceIds(user.place),
+        });
+      }
+    }
+    return [...byUsername.values()];
+  }
+}
+
+// UserInfo.place comes back from the CHT API in several shapes (CouchDoc[] | CouchDoc |
+// string[] | string); normalize it to a flat list of place ids.
+function normalizePlaceIds(place: UserInfo['place']): string[] {
+  const places = Array.isArray(place) ? place : [place];
+  return places
+    .map(p => (typeof p === 'string' ? p : (p as CouchDoc)?._id))
+    .filter(Boolean) as string[];
+}

--- a/src/services/upload-manager.ts
+++ b/src/services/upload-manager.ts
@@ -201,6 +201,11 @@ export class UploadManager extends EventEmitter {
         place.creationDetails.username = creationDetails.username;
         place.creationDetails.password = creationDetails.password;
         place.creationDetails.created_at = created_at;
+        
+        if (place.creationDetails.placeId && !place.uploadError) {
+          RemotePlaceCache.add(place, api);
+        }
+        
         this.eventedPlaceStateChange(place, PlaceUploadState.SUCCESS);
       });
 

--- a/src/services/username.ts
+++ b/src/services/username.ts
@@ -1,0 +1,16 @@
+// Derives a CHT-safe username from a free-form source string (a person's name, or an
+// oidc_username). Keeps only [a-z0-9_]: spaces become underscores, other characters are
+// dropped, runs of underscores are collapsed, and the result is lowercased.
+export function sanitizeUsername(source: string | undefined): string {
+  const username = source
+    ?.replace(/[ ]/g, '_')
+    ?.replace(/[^a-zA-Z0-9_]/g, '')
+    ?.replace(/_+/g, '_')
+    ?.toLowerCase();
+
+  if (!username) {
+    throw Error('username cannot be empty');
+  }
+
+  return username;
+}

--- a/test/lib/remote-place-cache.spec.ts
+++ b/test/lib/remote-place-cache.spec.ts
@@ -63,6 +63,39 @@ describe('lib/remote-place-cache.ts', () => {
     expect(chtApi.getPlacesWithType.callCount).to.eq(2);
   });
 
+  it('add keys on the created CHT placeId, not the local staging id', async () => {
+    const contactType = mockSimpleContactType('string', undefined);
+    const place = mockPlace(contactType, 'prop');
+    place.creationDetails.placeId = 'created-cht-id';
+    const chtApi = mockChtApi([doc]);
+
+    await RemotePlaceCache.getRemotePlaces(chtApi, contactType);
+    RemotePlaceCache.add(place, chtApi);
+
+    const second = await RemotePlaceCache.getRemotePlaces(chtApi, contactType);
+    expect(second).to.have.property('length', 2);
+    expect(second[1].id).to.eq('created-cht-id');
+
+    // re-adding the same created place must dedupe rather than duplicate
+    RemotePlaceCache.add(place, chtApi);
+    const third = await RemotePlaceCache.getRemotePlaces(chtApi, contactType);
+    expect(third).to.have.property('length', 2);
+  });
+
+  it('add is a no-op when the place type has not been cached yet', async () => {
+    const contactType = mockSimpleContactType('string', undefined);
+    const place = mockPlace(contactType, 'prop');
+    const chtApi = mockChtApi([doc]);
+
+    // never populated the cache for this type, so add() must not seed a partial list
+    RemotePlaceCache.add(place, chtApi);
+
+    const places = await RemotePlaceCache.getRemotePlaces(chtApi, contactType);
+    // the subsequent fetch loads the full remote set (just `doc`), unpolluted by the un-cached add
+    expect(places).to.have.property('length', 1);
+    expect(places[0]).to.deep.nested.include(docAsRemotePlace);
+  });
+
   it('clear', async () => {
     const contactType = mockSimpleContactType('string', undefined);
     const place = mockPlace(contactType, 'prop');

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -251,6 +251,36 @@ describe('routes/api.ts', () => {
       expect(hits.map((h: any) => h.place_id)).to.deep.equal(['p-jane']);
     });
 
+    it('clears the cache before searching when clear_cache=1', async () => {
+      const clearStub = sinon.stub(RemotePlaceCache, 'clear');
+      stubResolvedParent(fakeParent(PARENT_ID));
+      getRemotePlacesStub.resolves([fakeChild('p-jane', 'Jane Doe')]);
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/search?type=anything&clear_cache=1',
+        payload: { PARENT: 'parent', replacement: 'Jane Doe' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(clearStub.calledOnce).to.be.true;
+    });
+
+    it('does not clear the cache when clear_cache is absent', async () => {
+      const clearStub = sinon.stub(RemotePlaceCache, 'clear');
+      stubResolvedParent(fakeParent(PARENT_ID));
+      getRemotePlacesStub.resolves([fakeChild('p-jane', 'Jane Doe')]);
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/search?type=anything',
+        payload: { PARENT: 'parent', replacement: 'Jane Doe' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(clearStub.called).to.be.false;
+    });
+
     it('returns 500 when type is unknown', async () => {
       (Config.getContactType as sinon.SinonStub).restore();
       sinon.stub(Config, 'getContactType').throws(new Error('unrecognized contact type: "bogus"'));

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -291,7 +291,7 @@ describe('routes/api.ts', () => {
     });
   });
 
-  describe('POST /api/v1/deactivate-users', () => {
+  describe('POST /api/v1/disable-users-at', () => {
     it('deactivates users at the best-match facility resolved from the hierarchy', async () => {
       stubResolvedParent(fakeParent(PARENT_ID));
       getRemotePlacesStub.resolves([
@@ -302,7 +302,7 @@ describe('routes/api.ts', () => {
 
       const resp = await fastify.inject({
         method: 'POST',
-        url: '/api/v1/deactivate-users?type=anything',
+        url: '/api/v1/disable-users-at?type=anything',
         payload: { COUNTY: 'county', SUBCOUNTY: 'subcounty', CHU: 'chu', replacement: 'Jane Doe' },
       });
 
@@ -315,13 +315,34 @@ describe('routes/api.ts', () => {
       expect(deactivateUsersStub.calledOnceWithExactly(['chp-jane'], sinon.match.any)).to.be.true;
     });
 
+    it('aborts and skips deactivation when multiple facilities tie for the best match', async () => {
+      stubResolvedParent(fakeParent(PARENT_ID));
+      getRemotePlacesStub.resolves([
+        fakeChild('chp-jane', 'Jane Doe'),
+        fakeChild('chp-jane-dup', 'Jane Doe'),
+      ]);
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/disable-users-at?type=anything',
+        payload: { COUNTY: 'county', SUBCOUNTY: 'subcounty', CHU: 'chu', replacement: 'Jane Doe' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      const body = resp.json();
+      expect(body.success).to.be.false;
+      expect(body.isDuplicate).to.be.true;
+      expect(body.error).to.contain('tie for the best match');
+      expect(deactivateUsersStub.called).to.be.false;
+    });
+
     it('returns a not-found envelope and skips deactivation when no facility matches', async () => {
       stubResolvedParent(fakeParent(PARENT_ID));
       getRemotePlacesStub.resolves([fakeChild('chp-elsewhere', 'Jane Doe', 'other-parent')]);
 
       const resp = await fastify.inject({
         method: 'POST',
-        url: '/api/v1/deactivate-users?type=anything',
+        url: '/api/v1/disable-users-at?type=anything',
         payload: { COUNTY: 'county', replacement: 'Jane Doe' },
       });
 
@@ -338,7 +359,7 @@ describe('routes/api.ts', () => {
 
       const resp = await fastify.inject({
         method: 'POST',
-        url: '/api/v1/deactivate-users?type=anything',
+        url: '/api/v1/disable-users-at?type=anything',
         payload: { COUNTY: 'wrong', replacement: 'Jane Doe' },
       });
 
@@ -354,7 +375,7 @@ describe('routes/api.ts', () => {
     it('rejects a non-object body (array)', async () => {
       const resp = await fastify.inject({
         method: 'POST',
-        url: '/api/v1/deactivate-users?type=anything',
+        url: '/api/v1/disable-users-at?type=anything',
         payload: ['not', 'an', 'object'],
       });
 
@@ -672,7 +693,7 @@ describe('routes/api.ts', () => {
       const resp = await fastify.inject({
         method: 'POST',
         url: '/api/v1/create-user',
-        payload: { oidc_username: 'demo@email.com', role: 'chw', facility_ids: [] },
+        payload: { oidc_username: 'demo@email.com', role: 'chw', facility_ids: [], contact_id: 'contact-1' },
       });
 
       expect(resp.statusCode).to.equal(200);
@@ -680,6 +701,18 @@ describe('routes/api.ts', () => {
         success: false,
         errors: 'facility_ids must be a non-empty array of place ids',
       });
+      expect(createUserStub.called).to.be.false;
+    });
+
+    it('rejects a missing contact_id without calling createUser', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { oidc_username: 'demo@email.com', role: 'chw', facility_ids: ['fac-a'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ success: false, errors: 'contact_id is required' });
       expect(createUserStub.called).to.be.false;
     });
 
@@ -691,7 +724,7 @@ describe('routes/api.ts', () => {
       });
 
       expect(resp.statusCode).to.equal(200);
-      expect(resp.json()).to.deep.equal({ success: false, errors: 'contact_id must be a contact id' });
+      expect(resp.json()).to.deep.equal({ success: false, errors: 'contact_id is required' });
       expect(createUserStub.called).to.be.false;
     });
 
@@ -701,7 +734,7 @@ describe('routes/api.ts', () => {
       const resp = await fastify.inject({
         method: 'POST',
         url: '/api/v1/create-user',
-        payload: { oidc_username: 'dupe@email.com', role: 'chw', facility_ids: ['fac-a'] },
+        payload: { oidc_username: 'dupe@email.com', role: 'chw', facility_ids: ['fac-a'], contact_id: 'contact-1' },
       });
 
       expect(resp.statusCode).to.equal(200);

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -11,6 +11,7 @@ import Place, { PlaceUploadState } from '../../src/services/place';
 import WarningSystem from '../../src/warnings';
 import ManageHierarchyLib from '../../src/lib/manage-hierarchy';
 import { DisableUsers } from '../../src/lib/disable-users';
+import { SetUserFacilities } from '../../src/services/set-user-facilities';
 import { UnvalidatedPropertyValue } from '../../src/property-value';
 import { mockChtSession, mockValidContactType } from '../mocks';
 
@@ -61,6 +62,7 @@ describe('routes/api.ts', () => {
   let getJobDetailsStub: sinon.SinonStub;
   let scheduleJobStub: sinon.SinonStub;
   let deactivateUsersStub: sinon.SinonStub;
+  let setUserFacilitiesStub: sinon.SinonStub;
 
   /**
    * Configure PlaceFactory.createOne to return a Place stub whose
@@ -131,6 +133,9 @@ describe('routes/api.ts', () => {
     getJobDetailsStub = sinon.stub(ManageHierarchyLib, 'getJobDetails').resolves(fakeJob());
     scheduleJobStub = sinon.stub(ManageHierarchyLib, 'scheduleJob').resolves();
     deactivateUsersStub = sinon.stub(DisableUsers, 'deactivateUsersAt').resolves([]);
+    setUserFacilitiesStub = sinon.stub(SetUserFacilities, 'setFacilities').resolves({
+      username: 'target', facilityIds: ['fac-a'], unassigned: [],
+    });
   });
 
   afterEach(async () => {
@@ -353,6 +358,84 @@ describe('routes/api.ts', () => {
       expect(resp.statusCode).to.equal(500);
       expect(resp.json().message).to.contain('body expected as application/json');
       expect(deactivateUsersStub.called).to.be.false;
+    });
+  });
+
+  describe('POST /api/v1/set-user-facilities', () => {
+    it('sets the facilities for the user and returns the service result', async () => {
+      setUserFacilitiesStub.resolves({
+        username: 'jdoe',
+        facilityIds: ['fac-a', 'fac-b'],
+        unassigned: [{ username: 'other', remaining: ['fac-z'] }],
+      });
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/set-user-facilities',
+        payload: { username: 'jdoe', facility_ids: ['fac-a', 'fac-b'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        username: 'jdoe',
+        facilityIds: ['fac-a', 'fac-b'],
+        unassigned: [{ username: 'other', remaining: ['fac-z'] }],
+      });
+      const [username, facilityIds] = setUserFacilitiesStub.firstCall.args;
+      expect(username).to.equal('jdoe');
+      expect(facilityIds).to.deep.equal(['fac-a', 'fac-b']);
+    });
+
+    it('rejects a missing username without calling the service', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/set-user-facilities',
+        payload: { facility_ids: ['fac-a'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ success: false, errors: 'username is required' });
+      expect(setUserFacilitiesStub.called).to.be.false;
+    });
+
+    it('rejects an empty facility_ids array without calling the service', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/set-user-facilities',
+        payload: { username: 'jdoe', facility_ids: [] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        success: false,
+        errors: 'facility_ids must be a non-empty array of place ids',
+      });
+      expect(setUserFacilitiesStub.called).to.be.false;
+    });
+
+    it('returns the error envelope when the service throws', async () => {
+      setUserFacilitiesStub.rejects(new Error('Not Found'));
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/set-user-facilities',
+        payload: { username: 'ghost', facility_ids: ['fac-a'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ error: 'Error: Not Found' });
+    });
+
+    it('rejects a non-object body (array)', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/set-user-facilities',
+        payload: ['not', 'an', 'object'],
+      });
+
+      expect(resp.statusCode).to.equal(500);
+      expect(resp.json().message).to.contain('body expected as application/json');
+      expect(setUserFacilitiesStub.called).to.be.false;
     });
   });
 

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -10,6 +10,7 @@ import PlaceFactory from '../../src/services/place-factory';
 import Place, { PlaceUploadState } from '../../src/services/place';
 import WarningSystem from '../../src/warnings';
 import ManageHierarchyLib from '../../src/lib/manage-hierarchy';
+import { DisableUsers } from '../../src/lib/disable-users';
 import { UnvalidatedPropertyValue } from '../../src/property-value';
 import { mockChtSession, mockValidContactType } from '../mocks';
 
@@ -59,6 +60,7 @@ describe('routes/api.ts', () => {
   let uploadStub: sinon.SinonStub;
   let getJobDetailsStub: sinon.SinonStub;
   let scheduleJobStub: sinon.SinonStub;
+  let deactivateUsersStub: sinon.SinonStub;
 
   /**
    * Configure PlaceFactory.createOne to return a Place stub whose
@@ -128,6 +130,7 @@ describe('routes/api.ts', () => {
     setWarningsStub = sinon.stub(WarningSystem, 'setWarnings').resolves();
     getJobDetailsStub = sinon.stub(ManageHierarchyLib, 'getJobDetails').resolves(fakeJob());
     scheduleJobStub = sinon.stub(ManageHierarchyLib, 'scheduleJob').resolves();
+    deactivateUsersStub = sinon.stub(DisableUsers, 'deactivateUsersAt').resolves([]);
   });
 
   afterEach(async () => {
@@ -277,6 +280,79 @@ describe('routes/api.ts', () => {
 
       expect(resp.statusCode).to.equal(500);
       expect(resp.json().message).to.contain('body expected as application/json');
+    });
+  });
+
+  describe('POST /api/v1/deactivate-users', () => {
+    it('deactivates users at the best-match facility resolved from the hierarchy', async () => {
+      stubResolvedParent(fakeParent(PARENT_ID));
+      getRemotePlacesStub.resolves([
+        fakeChild('chp-jane', 'Jane Doe'),
+        fakeChild('chp-janet', 'Janet Doe'),
+      ]);
+      deactivateUsersStub.resolves(['user-a', 'user-b']);
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/deactivate-users?type=anything',
+        payload: { COUNTY: 'county', SUBCOUNTY: 'subcounty', CHU: 'chu', replacement: 'Jane Doe' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        place_id: 'chp-jane',
+        place_name: 'Jane Doe',
+        deactivated: ['user-a', 'user-b'],
+      });
+      expect(deactivateUsersStub.calledOnceWithExactly(['chp-jane'], sinon.match.any)).to.be.true;
+    });
+
+    it('returns a not-found envelope and skips deactivation when no facility matches', async () => {
+      stubResolvedParent(fakeParent(PARENT_ID));
+      getRemotePlacesStub.resolves([fakeChild('chp-elsewhere', 'Jane Doe', 'other-parent')]);
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/deactivate-users?type=anything',
+        payload: { COUNTY: 'county', replacement: 'Jane Doe' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        success: false,
+        error: 'no facility found matching the provided hierarchy',
+      });
+      expect(deactivateUsersStub.called).to.be.false;
+    });
+
+    it('propagates the hierarchy error envelope and skips deactivation', async () => {
+      stubResolvedParent(RemotePlaceResolver.NoResult);
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/deactivate-users?type=anything',
+        payload: { COUNTY: 'wrong', replacement: 'Jane Doe' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        error: 'hierarchy cannot be resolved: index 1 - Place Not Found',
+        parentMissing: true,
+        isAmbiguous: false,
+      });
+      expect(deactivateUsersStub.called).to.be.false;
+    });
+
+    it('rejects a non-object body (array)', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/deactivate-users?type=anything',
+        payload: ['not', 'an', 'object'],
+      });
+
+      expect(resp.statusCode).to.equal(500);
+      expect(resp.json().message).to.contain('body expected as application/json');
+      expect(deactivateUsersStub.called).to.be.false;
     });
   });
 

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -62,7 +62,7 @@ describe('routes/api.ts', () => {
   let uploadStub: sinon.SinonStub;
   let getJobDetailsStub: sinon.SinonStub;
   let scheduleJobStub: sinon.SinonStub;
-  let deactivateUsersStub: sinon.SinonStub;
+  let disableUsersStub: sinon.SinonStub;
   let setUserFacilitiesStub: sinon.SinonStub;
   let createUserStub: sinon.SinonStub;
 
@@ -134,7 +134,7 @@ describe('routes/api.ts', () => {
     setWarningsStub = sinon.stub(WarningSystem, 'setWarnings').resolves();
     getJobDetailsStub = sinon.stub(ManageHierarchyLib, 'getJobDetails').resolves(fakeJob());
     scheduleJobStub = sinon.stub(ManageHierarchyLib, 'scheduleJob').resolves();
-    deactivateUsersStub = sinon.stub(DisableUsers, 'deactivateUsersAt').resolves([]);
+    disableUsersStub = sinon.stub(DisableUsers, 'disableUsersAt').resolves([]);
     setUserFacilitiesStub = sinon.stub(SetUserFacilities, 'setFacilities').resolves({
       username: 'target', facilityIds: ['fac-a'], unassigned: [],
     });
@@ -322,13 +322,13 @@ describe('routes/api.ts', () => {
   });
 
   describe('POST /api/v1/disable-users-at', () => {
-    it('deactivates users at the best-match facility resolved from the hierarchy', async () => {
+    it('disables users at the best-match facility resolved from the hierarchy', async () => {
       stubResolvedParent(fakeParent(PARENT_ID));
       getRemotePlacesStub.resolves([
         fakeChild('chp-jane', 'Jane Doe'),
         fakeChild('chp-janet', 'Janet Doe'),
       ]);
-      deactivateUsersStub.resolves(['user-a', 'user-b']);
+      disableUsersStub.resolves(['user-a', 'user-b']);
 
       const resp = await fastify.inject({
         method: 'POST',
@@ -340,12 +340,12 @@ describe('routes/api.ts', () => {
       expect(resp.json()).to.deep.equal({
         place_id: 'chp-jane',
         place_name: 'Jane Doe',
-        deactivated: ['user-a', 'user-b'],
+        disabled: ['user-a', 'user-b'],
       });
-      expect(deactivateUsersStub.calledOnceWithExactly(['chp-jane'], sinon.match.any)).to.be.true;
+      expect(disableUsersStub.calledOnceWithExactly(['chp-jane'], sinon.match.any)).to.be.true;
     });
 
-    it('aborts and skips deactivation when multiple facilities tie for the best match', async () => {
+    it('aborts and skips disabling when multiple facilities tie for the best match', async () => {
       stubResolvedParent(fakeParent(PARENT_ID));
       getRemotePlacesStub.resolves([
         fakeChild('chp-jane', 'Jane Doe'),
@@ -363,10 +363,10 @@ describe('routes/api.ts', () => {
       expect(body.success).to.be.false;
       expect(body.isDuplicate).to.be.true;
       expect(body.error).to.contain('tie for the best match');
-      expect(deactivateUsersStub.called).to.be.false;
+      expect(disableUsersStub.called).to.be.false;
     });
 
-    it('returns a not-found envelope and skips deactivation when no facility matches', async () => {
+    it('returns a not-found envelope and skips disabling when no facility matches', async () => {
       stubResolvedParent(fakeParent(PARENT_ID));
       getRemotePlacesStub.resolves([fakeChild('chp-elsewhere', 'Jane Doe', 'other-parent')]);
 
@@ -381,10 +381,10 @@ describe('routes/api.ts', () => {
         success: false,
         error: 'no facility found matching the provided hierarchy',
       });
-      expect(deactivateUsersStub.called).to.be.false;
+      expect(disableUsersStub.called).to.be.false;
     });
 
-    it('propagates the hierarchy error envelope and skips deactivation', async () => {
+    it('propagates the hierarchy error envelope and skips disabling', async () => {
       stubResolvedParent(RemotePlaceResolver.NoResult);
 
       const resp = await fastify.inject({
@@ -399,7 +399,7 @@ describe('routes/api.ts', () => {
         parentMissing: true,
         isAmbiguous: false,
       });
-      expect(deactivateUsersStub.called).to.be.false;
+      expect(disableUsersStub.called).to.be.false;
     });
 
     it('rejects a non-object body (array)', async () => {
@@ -411,7 +411,7 @@ describe('routes/api.ts', () => {
 
       expect(resp.statusCode).to.equal(500);
       expect(resp.json().message).to.contain('body expected as application/json');
-      expect(deactivateUsersStub.called).to.be.false;
+      expect(disableUsersStub.called).to.be.false;
     });
   });
 

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -12,6 +12,7 @@ import WarningSystem from '../../src/warnings';
 import ManageHierarchyLib from '../../src/lib/manage-hierarchy';
 import { DisableUsers } from '../../src/lib/disable-users';
 import { SetUserFacilities } from '../../src/services/set-user-facilities';
+import { ChtApi } from '../../src/lib/cht-api';
 import { UnvalidatedPropertyValue } from '../../src/property-value';
 import { mockChtSession, mockValidContactType } from '../mocks';
 
@@ -63,6 +64,7 @@ describe('routes/api.ts', () => {
   let scheduleJobStub: sinon.SinonStub;
   let deactivateUsersStub: sinon.SinonStub;
   let setUserFacilitiesStub: sinon.SinonStub;
+  let createUserStub: sinon.SinonStub;
 
   /**
    * Configure PlaceFactory.createOne to return a Place stub whose
@@ -136,6 +138,7 @@ describe('routes/api.ts', () => {
     setUserFacilitiesStub = sinon.stub(SetUserFacilities, 'setFacilities').resolves({
       username: 'target', facilityIds: ['fac-a'], unassigned: [],
     });
+    createUserStub = sinon.stub(ChtApi.prototype, 'createUser').resolves();
   });
 
   afterEach(async () => {
@@ -584,6 +587,137 @@ describe('routes/api.ts', () => {
       expect(resp.statusCode).to.equal(500);
       expect(resp.json().message).to.contain('body expected as application/json');
       expect(uploadStub.called).to.be.false;
+    });
+  });
+
+  describe('POST /api/v1/create-user-and-place (alias of /create)', () => {
+    it('behaves like /api/v1/create', async () => {
+      stubCreatedPlace({ parent: fakeParent(PARENT_ID), id: 'p-1', contactId: 'c-1' });
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user-and-place?type=anything',
+        payload: { PARENT: 'parent', name: 'Jane Doe', phone: '0712345678' },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        place_id: 'p-1',
+        contact_id: 'c-1',
+        username: 'user-1',
+        password: 'pw-1',
+        warnings: [],
+      });
+      expect(uploadStub.calledOnce).to.be.true;
+    });
+  });
+
+  describe('POST /api/v1/create-user', () => {
+    it('creates an offline multi-place OIDC user with a derived username', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: {
+          oidc_username: 'demo@email.com', role: 'chw', facility_ids: ['fac-a', 'fac-b'], contact_id: 'contact-1',
+        },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ success: true, username: 'demoemailcom' });
+      expect(createUserStub.calledOnce).to.be.true;
+      expect({ ...createUserStub.firstCall.args[0] }).to.deep.equal({
+        username: 'demoemailcom',
+        oidc_username: 'demo@email.com',
+        roles: ['chw'],
+        place: ['fac-a', 'fac-b'],
+        contact: 'contact-1',
+      });
+    });
+
+    it('accepts a roles array', async () => {
+      await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { oidc_username: 'demo@email.com', roles: ['chw', 'supervisor'], facility_ids: ['fac-a'], contact_id: 'contact-1' },
+      });
+
+      expect(createUserStub.firstCall.args[0].roles).to.deep.equal(['chw', 'supervisor']);
+    });
+
+    it('rejects a missing oidc_username without calling createUser', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { role: 'chw', facility_ids: ['fac-a'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ success: false, errors: 'oidc_username is required' });
+      expect(createUserStub.called).to.be.false;
+    });
+
+    it('rejects a missing role without calling createUser', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { oidc_username: 'demo@email.com', facility_ids: ['fac-a'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ success: false, errors: 'role is required' });
+      expect(createUserStub.called).to.be.false;
+    });
+
+    it('rejects empty facility_ids without calling createUser', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { oidc_username: 'demo@email.com', role: 'chw', facility_ids: [] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({
+        success: false,
+        errors: 'facility_ids must be a non-empty array of place ids',
+      });
+      expect(createUserStub.called).to.be.false;
+    });
+
+    it('rejects a non-string contact_id without calling createUser', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { oidc_username: 'demo@email.com', role: 'chw', facility_ids: ['fac-a'], contact_id: 42 },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ success: false, errors: 'contact_id must be a contact id' });
+      expect(createUserStub.called).to.be.false;
+    });
+
+    it('returns the error envelope when createUser fails', async () => {
+      createUserStub.rejects({ response: { data: { error: { message: 'oidc_username already exists' } } } });
+
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: { oidc_username: 'dupe@email.com', role: 'chw', facility_ids: ['fac-a'] },
+      });
+
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.json()).to.deep.equal({ error: 'oidc_username already exists' });
+    });
+
+    it('rejects a non-object body (array)', async () => {
+      const resp = await fastify.inject({
+        method: 'POST',
+        url: '/api/v1/create-user',
+        payload: ['not', 'an', 'object'],
+      });
+
+      expect(resp.statusCode).to.equal(500);
+      expect(resp.json().message).to.contain('body expected as application/json');
+      expect(createUserStub.called).to.be.false;
     });
   });
 

--- a/test/services/oidc-user-payload.spec.ts
+++ b/test/services/oidc-user-payload.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+
+import { OidcUserPayload } from '../../src/services/oidc-user-payload';
+
+describe('OidcUserPayload', () => {
+  it('derives a CHT-safe username and carries facilities and contact', () => {
+    const payload = new OidcUserPayload('Demo.User@email.com', ['chw'], ['fac-a', 'fac-b'], 'contact-1');
+    expect(payload.username).to.equal('demouseremailcom');
+    expect(payload.oidc_username).to.equal('Demo.User@email.com');
+    expect(payload.roles).to.deep.equal(['chw']);
+    expect(payload.place).to.deep.equal(['fac-a', 'fac-b']);
+    expect(payload.contact).to.equal('contact-1');
+  });
+
+  it('collapses spaces and repeated separators when deriving the username', () => {
+    const payload = new OidcUserPayload('Jane   Doe', ['role'], ['fac-a'], 'contact-1');
+    expect(payload.username).to.equal('jane_doe');
+  });
+
+  it('carries exactly the fields needed to create the user', () => {
+    const payload = new OidcUserPayload('demo@email.com', ['chw'], ['fac-a'], 'contact-1');
+    expect(Object.keys({ ...payload }).sort())
+      .to.deep.equal(['contact', 'oidc_username', 'place', 'roles', 'username']);
+  });
+
+  it('throws when nothing usable can be derived for the username', () => {
+    expect(() => new OidcUserPayload('@@@', ['chw'], ['fac-a'], 'contact-1')).to.throw('username cannot be empty');
+  });
+});

--- a/test/services/set-user-facilities.spec.ts
+++ b/test/services/set-user-facilities.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { ChtApi, UserInfo } from '../../src/lib/cht-api';
+import { SetUserFacilities } from '../../src/services/set-user-facilities';
+
+function fakeChtApi(usersByFacility: Record<string, UserInfo[]>) {
+  return {
+    getUsersAtPlace: sinon.stub().callsFake(async (placeId: string) => usersByFacility[placeId] ?? []),
+    updateUser: sinon.stub().resolves(),
+  } as unknown as ChtApi & { getUsersAtPlace: sinon.SinonStub; updateUser: sinon.SinonStub };
+}
+
+describe('SetUserFacilities', () => {
+  afterEach(() => sinon.restore());
+
+  it('assigns the requested facilities to the target user (replacing their list)', async () => {
+    const chtApi = fakeChtApi({ 'fac-a': [], 'fac-b': [] });
+
+    const result = await SetUserFacilities.setFacilities('target', ['fac-a', 'fac-b'], chtApi);
+
+    expect(chtApi.updateUser.calledOnceWithExactly({ username: 'target', place: ['fac-a', 'fac-b'] })).to.be.true;
+    expect(result).to.deep.equal({ username: 'target', facilityIds: ['fac-a', 'fac-b'], unassigned: [] });
+  });
+
+  it('removes the reassigned facility from another user that held it', async () => {
+    const chtApi = fakeChtApi({
+      'fac-a': [{ username: 'other', place: [{ _id: 'fac-a' }, { _id: 'fac-z' }] }],
+    });
+
+    const result = await SetUserFacilities.setFacilities('target', ['fac-a'], chtApi);
+
+    // target assigned, then 'other' rewritten without fac-a but keeping fac-z
+    expect(chtApi.updateUser.firstCall.args[0]).to.deep.equal({ username: 'target', place: ['fac-a'] });
+    expect(chtApi.updateUser.secondCall.args[0]).to.deep.equal({ username: 'other', place: ['fac-z'] });
+    expect(result.unassigned).to.deep.equal([{ username: 'other', remaining: ['fac-z'] }]);
+  });
+
+  it('leaves a displaced user with an empty facility list (does not disable)', async () => {
+    const chtApi = fakeChtApi({
+      'fac-a': [{ username: 'other', place: ['fac-a'] }],
+    });
+
+    const result = await SetUserFacilities.setFacilities('target', ['fac-a'], chtApi);
+
+    expect(chtApi.updateUser.secondCall.args[0]).to.deep.equal({ username: 'other', place: [] });
+    expect(result.unassigned).to.deep.equal([{ username: 'other', remaining: [] }]);
+  });
+
+  it('does not unassign the target user even if it already held the facility', async () => {
+    const chtApi = fakeChtApi({
+      'fac-a': [{ username: 'target', place: ['fac-a'] }],
+    });
+
+    const result = await SetUserFacilities.setFacilities('target', ['fac-a'], chtApi);
+
+    expect(chtApi.updateUser.calledOnce).to.be.true; // only the assignment write
+    expect(result.unassigned).to.deep.equal([]);
+  });
+
+  it('rewrites a shared user once when they held several reassigned facilities', async () => {
+    const shared: UserInfo = { username: 'other', place: ['fac-a', 'fac-b', 'fac-keep'] };
+    const chtApi = fakeChtApi({ 'fac-a': [shared], 'fac-b': [shared] });
+
+    const result = await SetUserFacilities.setFacilities('target', ['fac-a', 'fac-b'], chtApi);
+
+    const otherWrites = chtApi.updateUser.getCalls().filter(c => c.args[0].username === 'other');
+    expect(otherWrites).to.have.length(1);
+    expect(otherWrites[0].args[0]).to.deep.equal({ username: 'other', place: ['fac-keep'] });
+    expect(result.unassigned).to.deep.equal([{ username: 'other', remaining: ['fac-keep'] }]);
+  });
+
+  it('normalizes the various place shapes returned by the CHT API', async () => {
+    // string-array place, single-string place, and CouchDoc-array place
+    const chtApi = fakeChtApi({
+      'fac-a': [
+        { username: 'str-arr', place: ['fac-a', 'fac-x'] },
+        { username: 'str', place: 'fac-a' as any },
+        { username: 'doc-arr', place: [{ _id: 'fac-a' }, { _id: 'fac-y' }] },
+      ],
+    });
+
+    const result = await SetUserFacilities.setFacilities('target', ['fac-a'], chtApi);
+
+    expect(result.unassigned).to.deep.equal([
+      { username: 'str-arr', remaining: ['fac-x'] },
+      { username: 'str', remaining: [] },
+      { username: 'doc-arr', remaining: ['fac-y'] },
+    ]);
+  });
+});


### PR DESCRIPTION
* Adds `/api/v1/create-user` - create CHA users in eCHIS when created in the registry
* Adds `/api/v1/disable-users-at` - to disable CHP users on exit
* Adds `/api/v1/set-user-facilities` - to reassign CHUs between CHAs
* Adds a `?clear_cache=1` param to `/api/v1/search`
* Renames `/api/v1/create` to `/api/v1/create-user-and-place` to disambiguate
* Resolves a caching bug in which places created via `/api/v1/create-user-and-place` can't be found via search without busting cache