### PR TITLE
fix(#352): wrap cell content so it doesn't overflow

### DIFF
--- a/src/liquid/components/list_cell.liquid
+++ b/src/liquid/components/list_cell.liquid
@@ -1,8 +1,10 @@
 <td
   id="{{ propertyName }}"
   {% if place.validationErrors[propertyName] %}
-    class="is-danger has-tooltip-arrow has-tooltipl-multiline"
+    class="cell-wrap is-danger has-tooltip-arrow has-tooltipl-multiline"
     data-tooltip="{{ place.validationErrors[propertyName] | escape }}"
+  {% else %}
+    class="cell-wrap"
   {% endif %}
 >
   {% if values[property.property_name] != empty %}

--- a/src/public/app.css
+++ b/src/public/app.css
@@ -16,3 +16,9 @@
   width: auto;
   right: 8;
 }
+
+.cell-wrap {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
+}


### PR DESCRIPTION
### description
Adds a cell wrap class that trims whitespace and wraps content so it doesn't overflow
#### before
<img width="616" height="203" alt="image" src="https://github.com/user-attachments/assets/429fafbd-7b9b-4291-a32a-7c8c575162a1" />


#### After

<img width="616" height="203" alt="image" src="https://github.com/user-attachments/assets/ea840566-d177-4ca4-9eca-279d4bf1f0a0" />


fixes #352

