### PR TITLE
fix(#358): clean search input

### DIFF
--- a/src/liquid/components/search_input.liquid
+++ b/src/liquid/components/search_input.liquid
@@ -1,4 +1,5 @@
 {% capture property_name %}{{prefix | default: 'place_' }}{{ hierarchy.property_name }}{% endcapture %}
+{% assign property_name_id = property_name | append: '_id' %}
 <div class="field" id="search_container_{{property_name}}">
   <label class="label">
     {{ hierarchy.friendly_name }}
@@ -10,14 +11,18 @@
       name="{{ property_name }}"
       type="search"
       class="input"
+      data-hierarchy-level="{{ hierarchy.level }}"
+      data-hierarchy-prefix="{{ prefix }}"
       hx-post="/search?place_id={{place.id}}&type={{ type }}&op={{op}}&level={{ hierarchy.level }}&prefix={{ prefix }}"
       hx-on::after-request="_paq.push(['trackEvent', 'Search', 'typing', '{{type}}']);"
+      hx-on:input="document.getElementById('{{ property_name_id }}')?.remove(); resetLowerHierarchyInputs(this)"
+      hx-on:blur="const i=this; setTimeout(function(){ if(!document.getElementById('{{ property_name_id }}')) { i.value=''; } }, 250)"
       hx-vals=""
       placeholder="start typing to see suggestions"
       hx-trigger="keyup changed delay:200ms, search"
       hx-target="#search_results_{{ property_name }}"
       hx-swap="innerHTML"
-      {% if required %}
+      {% if hierarchy.required %}
         required
       {% endif %}
       {% if data[property_name] %}
@@ -39,9 +44,8 @@
           <span class="is-size-7 has-text-primary req-indicator">Refreshing...</span>
           <span id="default" class="material-symbols-outlined">sync</span>
       </span>
-    {% assign property_name_id = property_name | append: '_id' %}
     {% if data[property_name_id] %}
-      <input name="{{property_name_id}}" value="{{data[property_name_id]}}" hidden>
+      <input id="{{property_name_id}}" name="{{property_name_id}}" value="{{data[property_name_id]}}" hidden>
     {% endif %}
     <div id="search_results_{{ property_name }}" class="control"></div>
   </div>

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -10,3 +10,29 @@
     }
   });
 })();
+
+//reset hierarchy search inputs if higher level input value changes
+function resetLowerHierarchyInputs(input) {
+  const level = parseInt(input.dataset.hierarchyLevel, 10);
+  const prefix = input.dataset.hierarchyPrefix || '';
+  if (isNaN(level) || prefix !== 'hierarchy_') {
+    return;
+  }
+
+  document.querySelectorAll('input[data-hierarchy-level]').forEach(function(otherInput) {
+    if (otherInput === input || (otherInput.dataset.hierarchyPrefix || '') !== prefix) {
+      return;
+    }
+    //dont reset higher hierarchy levels
+    if (parseInt(otherInput.dataset.hierarchyLevel, 10) >= level) {
+      return;
+    }
+    otherInput.value = '';
+    document.getElementById(otherInput.id + '_id')?.remove();
+    // clear dropdown
+    const results = document.getElementById('search_results_' + otherInput.id);
+    if (results) {
+      results.innerHTML = '';
+    }
+  });
+}


### PR DESCRIPTION
### Description
- Fixes search input required bug
   <img width="474" height="207" alt="Screenshot 2026-06-19 at 10 59 59" src="https://github.com/user-attachments/assets/60aff5c8-8132-4dc5-aa56-f7412fa62bd9" />
- User can only select from results dropdown. Manual input is removed once user clicks away from input field.

  https://github.com/user-attachments/assets/e3bbc9f7-2d2d-4528-b274-1ecabac271c3

- Editing a higher level hierarchy input resets all lower level inputs

  https://github.com/user-attachments/assets/accf41a4-83d0-43f7-ac7d-c3429c8d7958

Fixes #358 

