### PR TITLE
fix: navbar spacing issue

### DIFF
--- a/src/liquid/app/nav.liquid
+++ b/src/liquid/app/nav.liquid
@@ -83,7 +83,9 @@
       <div class="navbar-item has-dropdown is-hoverable">
         <a class="navbar-link is-arrowless">
           <span class="material-symbols-outlined">cloud</span>
-          Connected to <i>{{ session.authInfo.friendly }} as {{ session.username }}</i>
+          <span>
+            Connected to <i>{{ session.authInfo.friendly }} as {{ session.username }}</i>
+          </span>
         </a>
 
         <div class="navbar-dropdown is-right">


### PR DESCRIPTION
### Changes
Adds a span to navbar dropdown text
Before:
<img width="274" height="77" alt="Screenshot 2026-06-29 at 10 16 08" src="https://github.com/user-attachments/assets/979dc0c4-aad9-47e7-b176-f3275a8f02c1" />

After: 
<img width="278" height="63" alt="Screenshot 2026-06-29 at 10 16 43" src="https://github.com/user-attachments/assets/af8cce36-72fe-4e24-8924-93e0e51e5360" />


