### PR TITLE
fix(#364): refine fuzzy name matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "fastify": "^4.27.0",
         "fastify-metrics": "^11.0.0",
         "fastify-sse-v2": "^3.1.2",
-        "fuse.js": "^7.3.0",
         "html-minifier": "^4.0.0",
         "ioredis": "^5.4.1",
         "jsonwebtoken": "^9.0.2",
@@ -5838,19 +5837,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
-      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gaxios": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "fastify": "^4.27.0",
     "fastify-metrics": "^11.0.0",
     "fastify-sse-v2": "^3.1.2",
-    "fuse.js": "^7.3.0",
     "html-minifier": "^4.0.0",
     "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.2",

--- a/src/lib/name-match.ts
+++ b/src/lib/name-match.ts
@@ -1,0 +1,99 @@
+// Order-independent, token-aware name matching for eCHIS place lookup.
+//
+// Names arrive as free text — "First Middle Last", in any order, with any
+// number of parts — and must be matched against an eCHIS place name that may
+// drop or add a middle name, reorder the parts, or carry minor spelling drift.
+//
+// Scores run 0..1 where LOWER is better and 0 means identical.
+// `MATCH_THRESHOLD` is the single cutoff that turns a score into a verdict
+const MATCH_THRESHOLD = 0.25;
+
+export function normalize(value: string): string {
+  return value.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase().trim();
+}
+
+export function tokenize(value: string): string[] {
+  return [...new Set(normalize(value).split(/[\s-]+/).filter(Boolean))];
+}
+
+// Normalized similarity of two tokens in [0,1]; 1 = identical.
+function tokenSimilarity(a: string, b: string): number {
+  if (a === b) {
+    return 1;
+  }
+  const longest = Math.max(a.length, b.length);
+  return longest === 0 ? 1 : 1 - levenshtein(a, b) / longest;
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (!a.length) {
+    return b.length;
+  }
+  if (!b.length) {
+    return a.length;
+  }
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+// Mean, over each `from` token, of its best similarity against any `to` token.
+function coverage(from: string[], to: string[]): number {
+  return from.reduce((sum, token) => sum + Math.max(...to.map(other => tokenSimilarity(token, other))), 0) / from.length;
+}
+
+/**
+ * Order-independent name distance in [0,1]; 0 = identical token sets.
+ *
+ * Combines coverage in both directions (query→place and place→query) with their
+ * harmonic mean (F1), so a part present on only one side is tolerated but a name
+ * that merely shares a single common token is not enough.
+ */
+export function nameMatchScore(query: string, place: string): number {
+  const queryTokens = tokenize(query);
+  const placeTokens = tokenize(place);
+  if (!queryTokens.length || !placeTokens.length) {
+    return 1;
+  }
+
+  const forward = coverage(queryTokens, placeTokens);
+  const backward = coverage(placeTokens, queryTokens);
+  const f1 = forward + backward === 0 ? 0 : (2 * forward * backward) / (forward + backward);
+  return 1 - f1;
+}
+
+export function isNameMatch(query: string, place: string): boolean {
+  return nameMatchScore(query, place) <= MATCH_THRESHOLD;
+}
+
+export interface RankedNameMatch<T> {
+  item: T;
+  score: number;
+}
+
+/**
+ * Ranks `items` by how well their name matches `query`: keeps only those that
+ * clear the match verdict and orders them best-first (lowest score). The cutoff
+ * lives here — callers receive matches, not raw scores to threshold themselves.
+ */
+export function rankNameMatches<T>(
+  query: string,
+  items: T[],
+  nameOf: (item: T) => string,
+): RankedNameMatch<T>[] {
+  return items
+    .map(item => ({ item, score: nameMatchScore(query, nameOf(item)) }))
+    .filter(({ score }) => score <= MATCH_THRESHOLD)
+    .sort((a, b) => a.score - b.score);
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { ChtApi } from '../lib/cht-api';
 import { Config } from '../config';
 import { FastifyInstance, FastifyRequest } from 'fastify';
-import Fuse from 'fuse.js';
+import { rankNameMatches } from '../lib/name-match';
 import Place, { PlaceUploadState } from '../services/place';
 import PlaceFactory from '../services/place-factory';
 import ManageHierarchyLib from '../lib/manage-hierarchy';
@@ -14,8 +14,6 @@ import WarningSystem from '../warnings';
 import { DisableUsers } from '../lib/disable-users';
 import { SetUserFacilities } from '../services/set-user-facilities';
 import { OidcUserPayload } from '../services/oidc-user-payload';
-
-const DEFAULT_THRESHOLD = 0.6;
 
 type SearchResult = {
   place_id: string;
@@ -103,7 +101,7 @@ export default async function api(fastify: FastifyInstance) {
       RemotePlaceCache.clear(chtApi);
     }
 
-    const resolution = await resolvePlacesFromHierarchy(formBody, getThreshold(req.query), chtApi, req.sessionCache);
+    const resolution = await resolvePlacesFromHierarchy(formBody, chtApi, req.sessionCache);
     if ('error' in resolution) {
       return resolution;
     }
@@ -116,7 +114,7 @@ export default async function api(fastify: FastifyInstance) {
     ensureJsonObjectBody(formBody);
 
     const chtApi = new ChtApi(req.chtSession);
-    const resolution = await resolvePlacesFromHierarchy(formBody, getThreshold(req.query), chtApi, req.sessionCache);
+    const resolution = await resolvePlacesFromHierarchy(formBody, chtApi, req.sessionCache);
     if ('error' in resolution) {
       return resolution;
     }
@@ -250,22 +248,15 @@ function validateSetUserFacilities(username: unknown, facilityIds: unknown): str
   return null;
 }
 
-function getThreshold(query: unknown): number {
-  const threshold = (query as any)?.threshold;
-  return threshold !== undefined ? parseFloat(threshold) : DEFAULT_THRESHOLD;
-}
-
 function shouldClearCache(query: any): boolean {
   const raw = query?.clear_cache;
   return raw === '1' || raw === 1 || raw === 'true' || raw === true;
 }
 
-// Resolves the parent hierarchy from form data and fuzzy-matches the base-level place by name,
-// returning the candidate places ranked best-first. Shared by /search and /deactivate-users so
-// both resolve a facility identically.
+// Resolves the parent hierarchy from form data and matches the base-level place by name,
+// returning the matching places ranked best-first.
 async function resolvePlacesFromHierarchy(
   formBody: any,
-  threshold: number,
   chtApi: ChtApi,
   sessionCache: SessionCache,
 ): Promise<HierarchyResolutionError | { hits: SearchResult[] }> {
@@ -287,20 +278,13 @@ async function resolvePlacesFromHierarchy(
   const placesHavingParent = (await RemotePlaceCache.getRemotePlaces(chtApi, contactType, baseHierarchyLevel))
     .filter(remotePlace => remotePlace.lineage[0] === parentId);
 
-  const fuse = new Fuse(placesHavingParent, {
-    keys: ['name.formatted'],
-    includeScore: true,
-    threshold,
-  });
-
-  const hits: SearchResult[] = fuse
-    .search(formBody[baseHierarchyLevel.property_name] ?? '')
+  const searchString: string = formBody[baseHierarchyLevel.property_name] ?? '';
+  const hits: SearchResult[] = rankNameMatches(searchString, placesHavingParent, remotePlace => remotePlace.name.formatted)
     .map(({ item, score }) => ({
       name: item.name.original,
       place_id: item.id,
-      score: score ?? 1,
-    }))
-    .sort((a, b) => a.score - b.score);
+      score,
+    }));
 
   return { hits };
 }

--- a/test/lib/name-match.spec.ts
+++ b/test/lib/name-match.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+
+import { Config } from '../../src/config';
+import { RemotePlacePropertyValue } from '../../src/property-value';
+import { isNameMatch, nameMatchScore } from '../../src/lib/name-match';
+
+describe('lib/name-match.ts', () => {
+  // Verdict behavior: given the name as stored in eCHIS and the search string,
+  // assert whether they are treated as the same person. umt decides the verdict
+  // on its own — there is no caller-supplied threshold.
+  const cases: { search: string; echis: string; match: boolean }[] = [
+    { search: 'John Kamau Otieno',           echis: 'John Otieno',                    match: true },
+    { search: 'John Otieno',                 echis: 'John Kamau Otieno',              match: true },
+    { search: 'John Otieno',                 echis: 'Otieno John',                    match: true },
+    { search: 'Christine Wanyaga Muchiri',   echis: 'Christine Muchiri Wanyaga Area', match: true },
+    { search: 'CHARLES Barkasau BARGASAU',   echis: 'CHARLES BARGASAU Area',          match: true },
+    { search: 'MARGARET CHEMOIWO JEPSERGON', echis: 'MARGARET JEPSERGON Area',        match: true },
+    { search: 'John Otieno',                 echis: 'John Omondi',                    match: false },
+    { search: 'John',                        echis: 'John Otieno',                    match: false },
+  ];
+
+  for (const { search, echis, match } of cases) {
+    it(`${match ? 'matches' : 'rejects'}: "${search}" vs eCHIS "${echis}"`, () => {
+      expect(isNameMatch(search, asMatchedInKenya(echis))).to.equal(match);
+    });
+  }
+
+  it('is order-independent (score is symmetric)', () => {
+    expect(nameMatchScore('John Otieno', 'Otieno John')).to.equal(0);
+  });
+
+  it('ignores accents and case', () => {
+    expect(isNameMatch('joão', 'JOAO')).to.equal(true);
+  });
+});
+
+const areaType = Config.getContactType('d_community_health_volunteer_area');
+const placeNameProperty = Config.getHierarchyWithReplacement(areaType)[0];
+const asMatchedInKenya = (echisName: string) =>
+  new RemotePlacePropertyValue(echisName, placeNameProperty).formatted;
+

--- a/test/lib/name-match.spec.ts
+++ b/test/lib/name-match.spec.ts
@@ -36,6 +36,5 @@ describe('lib/name-match.ts', () => {
 
 const areaType = Config.getContactType('d_community_health_volunteer_area');
 const placeNameProperty = Config.getHierarchyWithReplacement(areaType)[0];
-const asMatchedInKenya = (echisName: string) =>
-  new RemotePlacePropertyValue(echisName, placeNameProperty).formatted;
+const asMatchedInKenya = (echisName: string) => new RemotePlacePropertyValue(echisName, placeNameProperty).formatted;
 

--- a/test/routes/api.spec.ts
+++ b/test/routes/api.spec.ts
@@ -165,7 +165,7 @@ describe('routes/api.ts', () => {
       const hits = resp.json();
       expect(hits.map((h: any) => h.place_id)).to.deep.equal(['p-jane', 'p-janet']);
       expect(hits[0].name).to.equal('Jane Doe');
-      expect(hits[0].score).to.be.lessThan(hits[1].score); // lower fuse score = better match
+      expect(hits[0].score).to.be.lessThan(hits[1].score); // lower score = better match
     });
 
     it('reports a missing parent in the body when no resolved place is found', async () => {
@@ -231,24 +231,6 @@ describe('routes/api.ts', () => {
       expect(dataPassed).to.deep.equal({ PARENT: 'p', GRANDPARENT: 'gp' });
       expect(dataPassed).to.not.have.property('replacement');
       expect(dataPassed).to.not.have.property('UNRELATED');
-    });
-
-    it('honours the query threshold by tightening Fuse cutoff', async () => {
-      stubResolvedParent(fakeParent(PARENT_ID));
-      getRemotePlacesStub.resolves([
-        fakeChild('p-jane', 'Jane Doe'),
-        fakeChild('p-totally', 'Totally Different XYZ'),
-      ]);
-
-      const resp = await fastify.inject({
-        method: 'POST',
-        url: '/api/v1/search?type=anything&threshold=0.1',
-        payload: { PARENT: 'parent', replacement: 'Jane Doe' },
-      });
-
-      expect(resp.statusCode).to.equal(200);
-      const hits = resp.json();
-      expect(hits.map((h: any) => h.place_id)).to.deep.equal(['p-jane']);
     });
 
     it('clears the cache before searching when clear_cache=1', async () => {


### PR DESCRIPTION
* Switches name matching algorithm from Fuse.js to levenshtein
* Tunes threshold parameter based on real-world examples from #364 (training) 
* Captures positive and negative cases for CHW-R name matching in tests so requirements can become clearer and algorithm can learn and grow
* Removes threshold parameter control from CHW-R. UMT owns the search verdict.

Of the 8 scenarios captured in #364, only 1 of them passed on `main`. All 8 of them are now passing in this branch.

Closes #364 