### PR TITLE
fix(#373): add chwregistry prod url for chis-ke

### DIFF
--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -210,6 +210,7 @@
     }
   ],
   "idpOrigins": [
+    "https://chwregistry.echis.go.ke",
     "https://chpregistry.echis.go.ke",
     "https://chwregistry-training.echis.go.ke",
     "https://chwregistry-dev.echis.go.ke",


### PR DESCRIPTION
- The production URL for CHW Registry is https://chwregistry.echis.go.ke and is not in idpOrigins