### PR TITLE
fix(#375): update echis area name stripping

### DIFF
--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -362,6 +362,7 @@
         "property_name": "replacement",
         "type": "name",
         "parameter": [
+          "['’]s\\s.*$",
           "\\sArea"
         ],
         "required": true

--- a/test/lib/name-match.spec.ts
+++ b/test/lib/name-match.spec.ts
@@ -15,6 +15,8 @@ describe('lib/name-match.ts', () => {
     { search: 'Christine Wanyaga Muchiri',   echis: 'Christine Muchiri Wanyaga Area', match: true },
     { search: 'CHARLES Barkasau BARGASAU',   echis: 'CHARLES BARGASAU Area',          match: true },
     { search: 'MARGARET CHEMOIWO JEPSERGON', echis: 'MARGARET JEPSERGON Area',        match: true },
+    { search: 'Benjamin Kiarie Muiruri',     echis: "Benjamin Kiarie's Community Health Volunteer Area", match: true },
+    { search: "James Ng'ang'a Kamau",        echis: "James Ng'ang'a's Community Health Volunteer Area",  match: true },
     { search: 'John Otieno',                 echis: 'John Omondi',                    match: false },
     { search: 'John',                        echis: 'John Otieno',                    match: false },
   ];

--- a/test/lib/name-match.spec.ts
+++ b/test/lib/name-match.spec.ts
@@ -17,6 +17,7 @@ describe('lib/name-match.ts', () => {
     { search: 'MARGARET CHEMOIWO JEPSERGON', echis: 'MARGARET JEPSERGON Area',        match: true },
     { search: 'Benjamin Kiarie Muiruri',     echis: "Benjamin Kiarie's Community Health Volunteer Area", match: true },
     { search: "James Ng'ang'a Kamau",        echis: "James Ng'ang'a's Community Health Volunteer Area",  match: true },
+    { search: "James Ng'sang Kamau",         echis: "James Ng'sang's Community Health Volunteer Area",   match: true },
     { search: 'John Otieno',                 echis: 'John Omondi',                    match: false },
     { search: 'John',                        echis: 'John Otieno',                    match: false },
   ];


### PR DESCRIPTION
Community Health Volunteer areas stored as `<name>'s Community Health Volunteer Area` failed to match the registry search name, because the chis-ke strip rule only removed " Area" — leaving the possessive 's, which pushed the fuzzy score over the match threshold.

Changes:
- `src/config/chis-ke/config.json `— CHV-area replacement property now also strips the possessive 's and trailing descriptor  before matching. Intra-name apostrophes (e.g. Ng'ang'a) are preserved.

Closes #375 