### PR TITLE
fix(#376): don't return external sources if contact type has no external source mapping

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -125,6 +125,10 @@ export class Config {
     return contactMatch;
   }
 
+  public static contactTypes(): ContactType[] {
+    return config.contact_types;
+  }
+
   public static getParentProperty(contactType: ContactType): HierarchyConstraint {
     const parentMatch = contactType.hierarchy.find(c => c.level === 1);
     if (!parentMatch) {
@@ -262,10 +266,6 @@ export class Config {
       ...contactType.hierarchy
     ]
       .some(prop => prop.external_mapping?.[sourceId]?.is_filter);
-  }
-
-  public static contactTypes(): ContactType[] {
-    return config.contact_types;
   }
 
   // get all external source parameters from configuration

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -117,16 +117,16 @@ const { config } = partnerConfig;
 export class Config {
   private constructor() { }
 
+  public static contactTypes(): ContactType[] {
+    return config.contact_types;
+  }
+  
   public static getContactType(name: string): ContactType {
     const contactMatch = config.contact_types.find(c => c.name === name);
     if (!contactMatch) {
       throw new Error(`unrecognized contact type: "${name}"`);
     }
     return contactMatch;
-  }
-
-  public static contactTypes(): ContactType[] {
-    return config.contact_types;
   }
 
   public static getParentProperty(contactType: ContactType): HierarchyConstraint {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -117,64 +117,12 @@ const { config } = partnerConfig;
 export class Config {
   private constructor() { }
 
-  public static getExternalSources(id?: string): ExternalSource[] {
-    if (id) {
-      const source = config.external_sources?.find(s => s.id === id);
-      if (!source) {
-        throw new Error(`external source with id "${id}" not found`);
-      }
-      return [source];
-    }
-    return config.external_sources || [];
-  }
-
-  public static getSanitizedExternalSources(): SanitizedExternalSource[] {
-    const result = config.external_sources?.map(s => ({ id: s.id, friendly_name: s.friendly_name })) || [];
-    return result;
-  }
-
-  public static contactTypes(): ContactType[] {
-    return config.contact_types;
-  }
-
   public static getContactType(name: string): ContactType {
     const contactMatch = config.contact_types.find(c => c.name === name);
     if (!contactMatch) {
       throw new Error(`unrecognized contact type: "${name}"`);
     }
     return contactMatch;
-  }
-
-  // get all external source parameters from configuration
-  public static getExternalSourceConfigById(sourceId: string, contactTypeName: string): ExternalSourceConfig {
-    const source = Config.getExternalSources(sourceId)[0];
-    const contactType: ContactType | undefined = config.contact_types.find(ct => ct.name === contactTypeName);
-    if (!contactType) {
-      throw new Error(`unrecognized contact type: "${contactTypeName}"`);
-    }
-    const getMappedProperties = (
-      properties: ContactProperty[] | HierarchyConstraint[],
-      type: 'place' | 'contact' | 'hierarchy'
-    ): ExternalSourceConfig['mapping'] => {
-      return properties.filter(prop => !!prop.external_mapping)
-        .map(prop => ({
-          propertyName: prop.property_name,
-          friendlyName: prop.friendly_name,
-          propertyType: type,
-          externalSourceField: prop.external_mapping?.[sourceId]?.name || '',
-          path: prop.external_mapping?.[sourceId]?.path,
-          isFilter: prop.external_mapping?.[sourceId]?.is_filter || false,
-        }));
-    };
-
-    return {
-      ...source,
-      mapping: [
-        ...getMappedProperties(contactType.contact_properties, 'contact'),
-        ...getMappedProperties(contactType.hierarchy, 'hierarchy'),
-        ...getMappedProperties(contactType.place_properties, 'place'),
-      ]
-    };
   }
 
   public static getParentProperty(contactType: ContactType): HierarchyConstraint {
@@ -285,6 +233,71 @@ export class Config {
     const contactMatch = config.contact_types.find(c => c.name === contactTypeName);
     const uniqueProperties = contactMatch?.place_properties.filter(prop => prop.unique);
     return uniqueProperties || [];
+  }
+
+  public static getExternalSources(id?: string): ExternalSource[] {
+    if (id) {
+      const source = config.external_sources?.find(s => s.id === id);
+      if (!source) {
+        throw new Error(`external source ${id} not found`);
+      }
+      return [source];
+    }
+    return config.external_sources || [];
+  }
+
+  public static getSanitizedExternalSources(contactTypeName: string, sourceId?: string): SanitizedExternalSource[] {
+    const contactType = Config.getContactType(contactTypeName);
+
+    const result = config.external_sources
+      ?.filter(source => Config.hasExternalSourceFilter(source.id, contactType) && (!sourceId || source.id === sourceId))
+      .map(s => ({ id: s.id, friendly_name: s.friendly_name })) || [];
+    return result;
+  }
+
+  private static hasExternalSourceFilter(sourceId: string, contactType: ContactType): boolean {
+    return [
+      ...contactType.contact_properties,
+      ...contactType.place_properties,
+      ...contactType.hierarchy
+    ]
+      .some(prop => prop.external_mapping?.[sourceId]?.is_filter);
+  }
+
+  public static contactTypes(): ContactType[] {
+    return config.contact_types;
+  }
+
+  // get all external source parameters from configuration
+  public static getExternalSourceConfigById(sourceId: string, contactTypeName: string): ExternalSourceConfig {
+    const source = Config.getExternalSources(sourceId)[0];
+    const contactType: ContactType | undefined = config.contact_types.find(ct => ct.name === contactTypeName);
+    if (!contactType) {
+      throw new Error(`unrecognized contact type: "${contactTypeName}"`);
+    }
+    const getMappedProperties = (
+      properties: ContactProperty[] | HierarchyConstraint[],
+      type: 'place' | 'contact' | 'hierarchy'
+    ): ExternalSourceConfig['mapping'] => {
+      return properties.filter(prop => !!prop.external_mapping)
+        .map(prop => ({
+          propertyName: prop.property_name,
+          friendlyName: prop.friendly_name,
+          propertyType: type,
+          externalSourceField: prop.external_mapping?.[sourceId]?.name || '',
+          path: prop.external_mapping?.[sourceId]?.path,
+          isFilter: prop.external_mapping?.[sourceId]?.is_filter || false,
+        }));
+    };
+
+    return {
+      ...source,
+      mapping: [
+        ...getMappedProperties(contactType.contact_properties, 'contact'),
+        ...getMappedProperties(contactType.hierarchy, 'hierarchy'),
+        ...getMappedProperties(contactType.place_properties, 'place'),
+      ]
+    };
   }
 
   // TODO: Joi? Chai?

--- a/src/routes/add-place.ts
+++ b/src/routes/add-place.ts
@@ -51,7 +51,7 @@ export default async function addPlace(fastify: FastifyInstance) {
     const queryParams: any = req.query;
     const { source_id: sourceId, type } = queryParams;
 
-   const [source] = Config.getExternalSources(sourceId);
+    const [source] = Config.getExternalSources(sourceId);
 
     const contactType = Config.getContactType(type);
     const tmplData = {
@@ -87,6 +87,10 @@ export default async function addPlace(fastify: FastifyInstance) {
 
     if (!source) {
       return renderError(`Unkown external source ${sourceId}`);
+    }
+    
+    if (Object.keys(searchParams).length === 0) {
+      return renderError('No search parameters provided');
     }
 
     try {

--- a/src/routes/add-place.ts
+++ b/src/routes/add-place.ts
@@ -15,11 +15,11 @@ export default async function addPlace(fastify: FastifyInstance) {
   fastify.get('/add-place', async (req, resp) => {
     const queryParams: any = req.query;
 
-    const externalSources = Config.getSanitizedExternalSources();
     const contactTypes = Config.contactTypes();
     const contactType = queryParams.type
       ? Config.getContactType(queryParams.type)
       : contactTypes[contactTypes.length - 1];
+    const externalSources = Config.getSanitizedExternalSources(contactType.name);
 
     const op = queryParams.op || 'new';
     if (
@@ -51,11 +51,7 @@ export default async function addPlace(fastify: FastifyInstance) {
     const queryParams: any = req.query;
     const { source_id: sourceId, type } = queryParams;
 
-    const externalSources = Config.getExternalSources();
-    const source = externalSources.find((source) => source.id === sourceId);
-    if (!source) {
-      throw new Error(`external source ${sourceId} not found`);
-    }
+   const [source] = Config.getExternalSources(sourceId);
 
     const contactType = Config.getContactType(type);
     const tmplData = {
@@ -76,9 +72,8 @@ export default async function addPlace(fastify: FastifyInstance) {
   fastify.get('/search-external-source', async (req, resp) => {
     const queryParams: any = req.query;
     const { source_id: sourceId, type, ...searchParams } = queryParams;
-    const externalSources = Config.getSanitizedExternalSources();
-    const source = externalSources.find((source) => source.id === sourceId);
     const contactType = Config.getContactType(type);
+    const [source] = Config.getSanitizedExternalSources(contactType.name, sourceId);
 
     const renderError = (error: string) => {
       return resp.view('src/liquid/place/search_external_source.liquid', {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { Config, PartnerConfig } from '../src/config';
-import { CONFIG_MAP } from '../src/config/config-factory';
+import { Config, ContactType, ExternalSource, PartnerConfig } from '../src/config';
+import getConfigByKey, { CONFIG_MAP } from '../src/config/config-factory';
 import { mockSimpleContactType } from './mocks';
 
 const mockPartnerConfig = (): PartnerConfig => ({
@@ -79,4 +80,142 @@ describe('config', () => {
       Config.assertValid(partnerConfig);
     });
   }
+});
+
+describe('config external sources', () => {
+  // the Config class reads from the singleton loaded via CONFIG_NAME (CHIS-KE by default in tests)
+  const loadedConfig = getConfigByKey(process.env.CONFIG_NAME).config;
+
+  const SOURCE_A: ExternalSource = {
+    id: 'source-a',
+    friendly_name: 'Source A',
+    url: 'https://a.example.com',
+    api_endpoint: '/api/search',
+    auth: { type: 'token', client_id_key: 'email', client_secret_key: 'password' },
+    resultKey: 'results',
+  };
+  const SOURCE_B: ExternalSource = { ...SOURCE_A, id: 'source-b', friendly_name: 'Source B' };
+
+  // builds a contact type whose `sex` place_property carries the given external_mapping
+  const contactTypeWithMapping = (external_mapping?: any): ContactType => {
+    const contactType = mockSimpleContactType('string');
+    contactType.place_properties[1].external_mapping = external_mapping;
+    return contactType;
+  };
+
+  let originalSources: ExternalSource[] | undefined;
+
+  beforeEach(() => {
+    originalSources = loadedConfig.external_sources;
+    loadedConfig.external_sources = [SOURCE_A, SOURCE_B];
+  });
+
+  afterEach(() => {
+    loadedConfig.external_sources = originalSources;
+    sinon.restore();
+  });
+
+  describe('getExternalSources', () => {
+    it('returns all configured sources when no id is provided', () => {
+      expect(Config.getExternalSources()).to.deep.equal([SOURCE_A, SOURCE_B]);
+    });
+
+    it('returns a single source in an array for a known id', () => {
+      expect(Config.getExternalSources('source-b')).to.deep.equal([SOURCE_B]);
+    });
+
+    it('throws for an unknown id', () => {
+      expect(() => Config.getExternalSources('missing')).to.throw('external source missing not found');
+    });
+
+    it('returns an empty array when no sources are configured', () => {
+      loadedConfig.external_sources = undefined;
+      expect(Config.getExternalSources()).to.deep.equal([]);
+    });
+
+    it('throws for any id when no sources are configured', () => {
+      loadedConfig.external_sources = undefined;
+      expect(() => Config.getExternalSources('source-a')).to.throw('external source source-a not found');
+    });
+  });
+
+  describe('getSanitizedExternalSources', () => {
+    it('returns a source when the contact type has a filter mapping for it', () => {
+      sinon.stub(Config, 'getContactType').returns(
+        contactTypeWithMapping({ 'source-a': { name: 'amount', is_filter: true } })
+      );
+
+      expect(Config.getSanitizedExternalSources('contacttype-name'))
+        .to.deep.equal([{ id: 'source-a', friendly_name: 'Source A' }]);
+    });
+
+    it('excludes a source that only has a non-filter mapping', () => {
+      sinon.stub(Config, 'getContactType').returns(
+        contactTypeWithMapping({ 'source-a': { name: 'x', is_filter: false } })
+      );
+
+      expect(Config.getSanitizedExternalSources('contacttype-name')).to.deep.equal([]);
+    });
+
+    it('excludes a source when is_filter is omitted', () => {
+      sinon.stub(Config, 'getContactType').returns(
+        contactTypeWithMapping({ 'source-a': { name: 'x' } })
+      );
+
+      expect(Config.getSanitizedExternalSources('contacttype-name')).to.deep.equal([]);
+    });
+
+    it('excludes all sources when the contact type has no external mapping', () => {
+      sinon.stub(Config, 'getContactType').returns(contactTypeWithMapping(undefined));
+
+      expect(Config.getSanitizedExternalSources('contacttype-name')).to.deep.equal([]);
+    });
+
+    it('detects a filter mapping declared on a hierarchy property', () => {
+      const contactType = mockSimpleContactType('string');
+      contactType.hierarchy[0].external_mapping = { 'source-b': { name: 'district', is_filter: true } };
+      sinon.stub(Config, 'getContactType').returns(contactType);
+
+      expect(Config.getSanitizedExternalSources('contacttype-name'))
+        .to.deep.equal([{ id: 'source-b', friendly_name: 'Source B' }]);
+    });
+
+    it('detects a filter mapping declared on a contact property', () => {
+      const contactType = mockSimpleContactType('string');
+      contactType.contact_properties[0].external_mapping = { 'source-a': { name: 'phone', is_filter: true } };
+      sinon.stub(Config, 'getContactType').returns(contactType);
+
+      expect(Config.getSanitizedExternalSources('contacttype-name'))
+        .to.deep.equal([{ id: 'source-a', friendly_name: 'Source A' }]);
+    });
+
+    it('filters to the requested sourceId when it has a filter mapping', () => {
+      sinon.stub(Config, 'getContactType').returns(
+        contactTypeWithMapping({
+          'source-a': { name: 'x', is_filter: true },
+          'source-b': { name: 'y', is_filter: true },
+        })
+      );
+
+      expect(Config.getSanitizedExternalSources('contacttype-name', 'source-b'))
+        .to.deep.equal([{ id: 'source-b', friendly_name: 'Source B' }]);
+    });
+
+    it('returns an empty array when the requested sourceId has no filter mapping', () => {
+      sinon.stub(Config, 'getContactType').returns(
+        contactTypeWithMapping({ 'source-a': { name: 'x', is_filter: true } })
+      );
+
+      expect(Config.getSanitizedExternalSources('contacttype-name', 'source-b')).to.deep.equal([]);
+    });
+
+    it('returns an empty array when no sources are configured', () => {
+      loadedConfig.external_sources = undefined;
+      sinon.stub(Config, 'getContactType').returns(
+        contactTypeWithMapping({ 'source-a': { name: 'x', is_filter: true } })
+      );
+
+      expect(Config.getSanitizedExternalSources('contacttype-name')).to.deep.equal([]);
+    });
+  });
 });

--- a/test/routes/add-place.spec.ts
+++ b/test/routes/add-place.spec.ts
@@ -75,7 +75,6 @@ describe('routes/add-place.ts external source routes', () => {
     });
 
     it('returns 500 when the source is unknown', async () => {
-      sinon.stub(Config, 'getExternalSources').returns([EXTERNAL_SOURCE] as any);
 
       const resp = await fastify.inject({
         method: 'GET',
@@ -115,6 +114,8 @@ describe('routes/add-place.ts external source routes', () => {
     });
 
     it('renders the search form with an error when the source is unknown', async () => {
+      (Config.getSanitizedExternalSources as sinon.SinonStub).restore();
+
       const resp = await fastify.inject({
         method: 'GET',
         url: '/search-external-source?source_id=missing&type=contacttype-name',


### PR DESCRIPTION
### Changes
- If contact type has no external source mapping return []
- adds external config tests
fixes #376 