### PR TITLE
fix(#380): ignore "Community Health Volunteer" in chp area names

### DIFF
--- a/src/config/chis-ke/config.json
+++ b/src/config/chis-ke/config.json
@@ -363,6 +363,9 @@
         "type": "name",
         "parameter": [
           "['’]s\\s.*$",
+          "\\sCommunity",
+          "\\sHealth",
+          "\\sVolunteer",
           "\\sArea"
         ],
         "required": true

--- a/test/lib/name-match.spec.ts
+++ b/test/lib/name-match.spec.ts
@@ -18,6 +18,8 @@ describe('lib/name-match.ts', () => {
     { search: 'Benjamin Kiarie Muiruri',     echis: "Benjamin Kiarie's Community Health Volunteer Area", match: true },
     { search: "James Ng'ang'a Kamau",        echis: "James Ng'ang'a's Community Health Volunteer Area",  match: true },
     { search: "James Ng'sang Kamau",         echis: "James Ng'sang's Community Health Volunteer Area",   match: true },
+    { search: 'NANCY LUGUNGO SAMBIANI',      echis: 'Nancy Sambiani Community Health Volunteer Area',    match: true },
+
     { search: 'John Otieno',                 echis: 'John Omondi',                    match: false },
     { search: 'John',                        echis: 'John Otieno',                    match: false },
   ];


### PR DESCRIPTION
#380 