### PR TITLE
fix(#382): make doUpload trigger cht request once for same place

### DIFF
--- a/src/services/upload-manager.ts
+++ b/src/services/upload-manager.ts
@@ -33,8 +33,11 @@ export class UploadManager extends EventEmitter {
   };
 
   doUpload = async (places: Place[], chtApi: ChtApi, ignoreWarnings: boolean = false) => {
+    const inFlightStates = [PlaceUploadState.SCHEDULED, PlaceUploadState.IN_PROGRESS];
     const validPlaces = places.filter(p => {
-      return !p.hasValidationErrors && (ignoreWarnings || !p.warnings.length);
+      return !p.hasValidationErrors
+        && (ignoreWarnings || !p.warnings.length)
+        && !inFlightStates.includes(p.state);
     });
     const placesNeedingUpload = validPlaces.filter(p => !p.isCreated);
     this.eventedPlaceStateChange(placesNeedingUpload, PlaceUploadState.SCHEDULED);

--- a/test/services/upload-manager.spec.ts
+++ b/test/services/upload-manager.spec.ts
@@ -364,6 +364,32 @@ describe('services/upload-manager.ts', () => {
     expect(place.isCreated).to.be.true;
   });
 
+  it('doUpload is idempotent while an upload is in flight', async () => {
+    const { fakeFormData, contactType, sessionCache, chtApi, uploadLogger } = await createMocks();
+    const place = await PlaceFactory.createOne(fakeFormData, contactType, sessionCache, chtApi);
+
+    let resolveCreatePlace: (result: any) => void = () => {};
+    // freeze createPlace so we can call doUpload thrice before it resolves
+    chtApi.createPlace = sinon.stub().returns(new Promise(resolve => {
+      resolveCreatePlace = resolve;
+    }));
+
+    const uploadManager = new UploadManager(uploadLogger);
+
+    // mock 3 in-flight concurrent calls for the same place, 
+    // only one should actually call createPlace
+    const firstUpload = uploadManager.doUpload([place], chtApi);
+    const secondUpload = uploadManager.doUpload([place], chtApi);
+    const thirdUpload = uploadManager.doUpload([place], chtApi);
+
+    resolveCreatePlace({ placeId: 'created-place-id', contactId: 'created-contact-id' });
+    await Promise.all([firstUpload, secondUpload, thirdUpload]);
+
+    expect(chtApi.createPlace.calledOnce).to.be.true;
+    expect(chtApi.createUser.calledOnce).to.be.true;
+    expect(place.isCreated).to.be.true;
+  });
+
   it('#173 - replacement when place has no primary contact', async () => {
     const { subcounty, sessionCache, contactType, fakeFormData, chtApi, uploadLogger } = await createMocks();
     const toReplace: ChtDoc = {


### PR DESCRIPTION
### changes
- doUpload filters out places that are already scheduled or in progress
- only makes one CHT set of CHT calls(crreatecontact, createuser etc) for the same place
fixes #382 